### PR TITLE
マイグレーションしようとしたところエラーが出たので、修正。

### DIFF
--- a/database/migrations/2021_10_07_062428_create_memos_table.php
+++ b/database/migrations/2021_10_07_062428_create_memos_table.php
@@ -18,7 +18,7 @@ class CreateMemosTable extends Migration
             $table->integer('user_id')->comment('usersテーブルのid');
             $table->string('title')->comment('メモのタイトル');
             $table->json('memo_data')->comment('editor.jsで作成したjsonメモデータ');
-            $table->timestamps()->comment('タイムスタンプ');
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2021_10_07_063628_create_categories_table.php
+++ b/database/migrations/2021_10_07_063628_create_categories_table.php
@@ -16,7 +16,7 @@ class CreateCategoriesTable extends Migration
         Schema::create('categories', function (Blueprint $table) {
             $table->id()->comment('自動増分値');
             $table->string('name')->comment('カテゴリー名');
-            $table->timestamps()->comment('タイムスタンプ');
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2021_10_23_151904_category_memos_table.php
+++ b/database/migrations/2021_10_23_151904_category_memos_table.php
@@ -17,7 +17,7 @@ class CategoryMemosTable extends Migration
             $table->id()->comment('自動増分値');
             $table->integer('category_id')->comment('categoriesテーブルのid');
             $table->integer('memo_id')->comment('memosテーブルのid');
-            $table->timestamps()->comment('タイムスタンプ');
+            $table->timestamps();
         });
     }
 


### PR DESCRIPTION
マイグレーションしたところ、スクリーンショット1枚目のエラーが出たので原因を探ったところtimestampにもcommentを付加していたことが理由だとわかりました。
なので、timestampからcommentを削除しました(カラム名としても役割が明白なため。
commentを削除したところ、2枚目のスクリーンショットの通りに正常に動きました。
timestampはcreated_atとupdated_atの2つを含んでおり、nullを許容するために起きたエラーでした。
![スクリーンショット 2021-10-24 141731](https://user-images.githubusercontent.com/42739038/138581935-b1f44cc7-8a51-4d15-8bb1-584e4e36388d.png)
![スクリーンショット 2021-10-24 141756](https://user-images.githubusercontent.com/42739038/138581940-34d710e4-1969-4ce2-bc70-4438b4712705.png)

