### PR TITLE
ホーム画面にてメモデータを読み込む処理を実装。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -22,10 +22,17 @@ class MemoController extends Controller
 
     /**
      * 全memoレコードの取得
+     * 
+     * @return array $memos
+     * $user_idに該当するアカウントの全メモデータ。
      */
     public function index()
     {
-
+        $user_id = Auth::id();
+        //後でカテゴリーの参照とViewへの返却も実装
+        $memos = Memo::where('user_id', $user_id)->get();
+        $memo_data = Memo::where('user_id', $user_id)->get('memo_data');
+        return view('EngineerStack.home', compact('memos', 'memo_data'));
     }
 
     public function create()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
                 "@editorjs/editorjs": "^2.22.2",
                 "@fortawesome/fontawesome-free": "^5.15.4",
                 "bulma": "^0.9.3",
+                "editorjs-html": "^3.4.2",
                 "font-awesome": "^4.7.0",
                 "jquery": "^3.6.0"
             },
@@ -4008,6 +4009,11 @@
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
+        },
+        "node_modules/editorjs-html": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/editorjs-html/-/editorjs-html-3.4.2.tgz",
+            "integrity": "sha512-Gy8FV4oHMvnPDXLsdpZYW0Dgjaagff9bPd28/WW9aFdy87FvktJxQz8H+NKpxiGcGoNY27MmjFffurK2yhXjEg=="
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -12948,6 +12954,11 @@
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
+        },
+        "editorjs-html": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/editorjs-html/-/editorjs-html-3.4.2.tgz",
+            "integrity": "sha512-Gy8FV4oHMvnPDXLsdpZYW0Dgjaagff9bPd28/WW9aFdy87FvktJxQz8H+NKpxiGcGoNY27MmjFffurK2yhXjEg=="
         },
         "ee-first": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@editorjs/editorjs": "^2.22.2",
         "@fortawesome/fontawesome-free": "^5.15.4",
         "bulma": "^0.9.3",
+        "editorjs-html": "^3.4.2",
         "font-awesome": "^4.7.0",
         "jquery": "^3.6.0"
     }

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -168,6 +168,7 @@
             const editor = new  EditorJS({
                 holder: 'editorjs',
                 readOnly: true,
+                minHeight: 50,
                 data: memoData
             });
         });
@@ -182,7 +183,7 @@
             let second_str = date.getSeconds();
             
             
-            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に作成';
+            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に投稿';
             format_str = format_str.replace(/YYYY/g, year_str);
             format_str = format_str.replace(/MM/g, month_str);
             format_str = format_str.replace(/DD/g, day_str);

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -45,6 +45,128 @@
             </div>
         </nav>
     </section>
+    @if(isset($memos))
+        <section class="content">
+            <div class="title has-text-centered m-5">
+                <p class="is-size-4 is-text-weight-bold">最近のメモ</p>
+            </div>
+            <div class="columns">
+                <div class="column is-one-thirds">
+                    <div class="category p-5">
+                        <span class="tag"><i class="fas fa-tape"></i>php</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>Laravel</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>SQL</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>MVC</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>CRUD</span><br>
+                        <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>悩んだ点</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>解決策</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>javascript</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>qiita</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>zenn</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>気づき</span><br>
+                        <span class="tag"><i class="fas fa-tape"></i>アイデア</span><br>
+                    </div>
+                </div>
+                <div class="column is-one-thirds">
+                    <div class="memos">
+                        <div class="memo box column m-3">
+                            <div class="category">
+                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
+                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
+                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
+                                <span class="tag"><i class="fas fa-tape"></i>php</span>
+                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
+                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
+                            </div><br>
+                            <div class="title">
+                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[0]->title }}</h4>
+                            </div>
+                            <div id="data_0">
+                            </div><br>
+                            <div class="post-time">
+                                <p id="time_0"></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-one-thirds">
+                    <div class="memos">
+                        <div class="memo box column m-3">
+                            <div class="category">
+                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
+                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
+                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
+                                <span class="tag"><i class="fas fa-tape"></i>php</span>
+                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
+                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
+                            </div><br>
+                            <div class="title">
+                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[1]->title }}</h4>
+                            </div>
+                            <div id="data_1">
+                            </div><br>
+                            <div class="post-time">
+                                <p id="time_1"></p>
+                            </div>
+                        </div>
+                        <div class="memo box column m-3">
+                            <div class="category">
+                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
+                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
+                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
+                                <span class="tag"><i class="fas fa-tape"></i>php</span>
+                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
+                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
+                            </div><br>
+                            <div class="title">
+                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[2]->title }}</h4>
+                            </div>
+                            <div id="data_2">
+                            </div><br>
+                            <div class="post-time">
+                                <p id="time_2"></p>
+                            </div>
+                        </div>
+                        <div class="memo box column m-3">
+                            <div class="category">
+                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
+                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
+                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
+                                <span class="tag"><i class="fas fa-tape"></i>php</span>
+                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
+                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
+                            </div><br>
+                            <div class="title">
+                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[3]->title }}</h4>
+                            </div>
+                            <div id="data_3">
+                            </div><br>
+                            <div class="post-time">
+                                <p id="time_3"></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="columns">
+                <div class="column">
+                    <div class="paging has-text-centered mt-5">
+                        <a href="">1</a>
+                        <a href="">2</a>
+                        <a href="">3</a>
+                        <a href="">4</a>
+                        <a class="ml-5" href="">次へ</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    @else 
+        <section class="content">
+
+        </section>
+    @endisset
     <section class="footer">
         <div class="columns">
             <div class="column">
@@ -64,5 +186,58 @@
     </section>
     <script src="{{ asset('js/app.js') }}"></script>
     <script src="{{ asset('js/navbar.js') }}"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"
+                integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
+                crossorigin="anonymous">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
+    <script>
+        $(function () {
+            let memoData = @json($memo_data);
+
+            for(let index=0;index<4;index++) {
+                let data = memoData[index];
+                data = data['memo_data'];
+                data = JSON.parse(data);
+                let post_time = data.time;
+                post_time = new Date(post_time);
+                data = jsonConvertHtml(data);
+                let data_id = `#data_${index}`;
+                $(data_id).html(data);
+                console.log(post_time);
+                post_time = getStringFromDate(post_time);
+                let time_id = `#time_${index}`;
+                $(time_id).text(post_time);
+            } 
+        });
+
+        function getStringFromDate(date) {
+        
+            let year_str = date.getFullYear();
+            let month_str = 1 + date.getMonth();
+            let day_str = date.getDate();
+            let hour_str = date.getHours();
+            let minute_str = date.getMinutes();
+            let second_str = date.getSeconds();
+            
+            
+            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に投稿';
+            format_str = format_str.replace(/YYYY/g, year_str);
+            format_str = format_str.replace(/MM/g, month_str);
+            format_str = format_str.replace(/DD/g, day_str);
+            format_str = format_str.replace(/hh/g, hour_str);
+            format_str = format_str.replace(/mm/g, minute_str);
+            format_str = format_str.replace(/ss/g, second_str);
+            
+            return format_str;
+        };
+
+        function jsonConvertHtml(jsonData) {
+            const edjsParser = edjsHTML();
+            let html = edjsParser.parse(jsonData);
+            return html;
+        }
+    </script>
 </body>
 </html>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -45,13 +45,17 @@
             </div>
         </nav>
     </section>
-    @if(isset($memos))
+    @if($memos->isEmpty())
+        <section class="content">
+            <p>まだメモは投稿されていません。</p>
+        </section>
+    @else 
         <section class="content">
             <div class="title has-text-centered m-5">
                 <p class="is-size-4 is-text-weight-bold">最近のメモ</p>
             </div>
             <div class="columns">
-                <div class="column is-one-thirds">
+                <div class="column is-2">
                     <div class="category p-5">
                         <span class="tag"><i class="fas fa-tape"></i>php</span><br>
                         <span class="tag"><i class="fas fa-tape"></i>Laravel</span><br>
@@ -69,9 +73,9 @@
                         <span class="tag"><i class="fas fa-tape"></i>アイデア</span><br>
                     </div>
                 </div>
-                <div class="column is-one-thirds">
-                    <div class="memos">
-                        <div class="memo box column m-3">
+                <div class="memos columns is-multiline">
+                    @foreach($memos as $memo)
+                        <div class="memo column is-5 box m-3">
                             <div class="category">
                                 <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
                                 <span class="tag"><i class="fas fa-tape"></i>ログ</span>
@@ -81,73 +85,15 @@
                                 <span class="tag"><i class="fas fa-tape"></i>MVC</span>
                             </div><br>
                             <div class="title">
-                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[0]->title }}</h4>
+                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memo->title }}</h4>
                             </div>
-                            <div id="data_0">
+                            <div id="data_{{ $loop->index }}">
                             </div><br>
                             <div class="post-time">
-                                <p id="time_0"></p>
+                                <p>{{ $memo->created_at->format('Y年m月d日投稿') }}</p>
                             </div>
                         </div>
-                    </div>
-                </div>
-                <div class="column is-one-thirds">
-                    <div class="memos">
-                        <div class="memo box column m-3">
-                            <div class="category">
-                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
-                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
-                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
-                                <span class="tag"><i class="fas fa-tape"></i>php</span>
-                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
-                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
-                            </div><br>
-                            <div class="title">
-                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[1]->title }}</h4>
-                            </div>
-                            <div id="data_1">
-                            </div><br>
-                            <div class="post-time">
-                                <p id="time_1"></p>
-                            </div>
-                        </div>
-                        <div class="memo box column m-3">
-                            <div class="category">
-                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
-                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
-                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
-                                <span class="tag"><i class="fas fa-tape"></i>php</span>
-                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
-                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
-                            </div><br>
-                            <div class="title">
-                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[2]->title }}</h4>
-                            </div>
-                            <div id="data_2">
-                            </div><br>
-                            <div class="post-time">
-                                <p id="time_2"></p>
-                            </div>
-                        </div>
-                        <div class="memo box column m-3">
-                            <div class="category">
-                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
-                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
-                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
-                                <span class="tag"><i class="fas fa-tape"></i>php</span>
-                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
-                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
-                            </div><br>
-                            <div class="title">
-                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memos[3]->title }}</h4>
-                            </div>
-                            <div id="data_3">
-                            </div><br>
-                            <div class="post-time">
-                                <p id="time_3"></p>
-                            </div>
-                        </div>
-                    </div>
+                    @endforeach
                 </div>
             </div>
             <div class="columns">
@@ -162,11 +108,7 @@
                 </div>
             </div>
         </section>
-    @else 
-        <section class="content">
-
-        </section>
-    @endisset
+    @endif
     <section class="footer">
         <div class="columns">
             <div class="column">
@@ -195,17 +137,17 @@
     <script>
         $(function () {
             let memoData = @json($memo_data);
+            let memoLength = JSON.parse(JSON.stringify(memoData)).length;
 
-            for(let index=0;index<4;index++) {
+            for(let index=0;index<memoLength;index++) {
                 let data = memoData[index];
-                data = data['memo_data'];
+                data = data.memo_data;
                 data = JSON.parse(data);
                 let post_time = data.time;
                 post_time = new Date(post_time);
                 data = jsonConvertHtml(data);
                 let data_id = `#data_${index}`;
                 $(data_id).html(data);
-                console.log(post_time);
                 post_time = getStringFromDate(post_time);
                 let time_id = `#time_${index}`;
                 $(time_id).text(post_time);

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -132,6 +132,7 @@
     <script>
         $(function() {
             const editor = new EditorJS({
+                minHeight: 50,
                 holder: 'editorjs'
             });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,9 +8,7 @@ Route::get('/', function () {
     return view('auth.register');
 });
 
-Route::get('/dashboard', function () {
-    return view('EngineerStack.home');
-})->middleware(['auth'])->name('dashboard');
+Route::get('/dashboard', [MemoController::class, 'index'])->middleware(['auth'])->name('dashboard');
 
 Route::prefix('user')->group(function () {
 


### PR DESCRIPTION
editorjs-htmlというeditor.jsで作成したテキストデータをjsonに直して渡すと、返り値としてHTMLが返却されるプラグインを導入しました。
bladeにて、アカウントを作成したばかりの初期状態などのメモデータが存在しないときのために、home.blade.phpでisEmptyメソッドを用いて処理を分けました。
コードレビューよろしくお願いします。
home.blade.phpのスクショです↓
![スクリーンショット 2021-11-04 162741](https://user-images.githubusercontent.com/42739038/140274356-e65f4812-841b-452f-811b-12ce9b8c7d86.png)
![スクリーンショット 2021-11-04 162803](https://user-images.githubusercontent.com/42739038/140274362-55b3283f-2d50-4dbc-8b11-6b49e62c7eea.png)

