### PR TITLE
メモ更新機能を作成。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -35,11 +35,6 @@ class MemoController extends Controller
         return view('EngineerStack.home', compact('memos', 'memo_data'));
     }
 
-    public function create()
-    {
-
-    }
-
     /**
      * memoレコードを1件DBに保存
      * 
@@ -118,7 +113,7 @@ class MemoController extends Controller
             //TODO: カテゴリ機能実装時に必ず修正。
             $categories = "php, Laravel, MVC, EngineerStack";
             $memo_data = Memo::find($memo_id)->memo_data;
-           return view('EngineerStack.detailed_memo',
+            return view('EngineerStack.detailed_memo',
                     compact('title', 'categories', 'memo_data', 'memo_id'));
         }
     }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -65,19 +65,62 @@ class MemoController extends Controller
     /**
      * 指定memoレコードの編集
      * @param  int  $id
+     * TODO: 後ほど、user_idが異なるアカウントでredirectが
+     * 発動するかテスト
      */
     public function edit($id)
     {
-
+        $memo_id = $id;
+        $memo = Memo::find($memo_id);
+        $memo_owner = $memo->user_id;
+        if($memo_owner != Auth::id()) {
+            redirect()->route('dashboard');
+        } else {
+            $memo_data = $memo['memo_data'];
+            return view('EngineerStack.edit_memo'
+                    , compact('memo', 'memo_data'));
+        }
     }
 
     /**
      * 指定memoレコードの更新
      * @param  int  $id
+     * 
      */
-    public function update($id)
+    public function update(Request $request)
     {
+        $memo_id = $request->input('memo_id');
+        $memo_data = $request->input('memo_data');
+        $memo_owner = Memo::find($memo_id)->user_id;
+        if($memo_owner != Auth::id()) {
+            redirect()->route('dashboard');
+        } else {
+            //更新処理
+            Memo::where('id', $memo_id)->update(['memo_data' => $memo_data]);
+            $title = Memo::find($memo_id)->title;
+            //TODO: カテゴリ機能実装時に必ず修正。
+            $categories = "php, Laravel, MVC, EngineerStack";
+            $memo_data = Memo::find($memo_id)->memo_data;
+            return view('EngineerStack.detailed_memo'
+                    , compact('title', 'categories', 'memo_data', 'memo_id'));
+        }
+    }
 
+    public function show(Request $request)
+    {
+        $memo_id = $request->input('memo_id');
+        $memo_data = $request->input('memo_data');
+        $memo_owner = Memo::find($memo_id)->user_id;
+        if($memo_owner != Auth::id()) {
+            redirect()->route('dashboard');
+        } else {
+            $title = Memo::find($memo_id)->title;
+            //TODO: カテゴリ機能実装時に必ず修正。
+            $categories = "php, Laravel, MVC, EngineerStack";
+            $memo_data = Memo::find($memo_id)->memo_data;
+           return view('EngineerStack.detailed_memo',
+                    compact('title', 'categories', 'memo_data', 'memo_id'));
+        }
     }
 
     /**

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -11,7 +11,7 @@
     <section class="header">
         <nav class="navbar" role="navigation" aria-label="main navigation">
             <div class="navbar-brand">
-                <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="">
+                <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
                 <div class="field mt-4 ml-5">
@@ -73,9 +73,10 @@
                             </div>
                             <div class="dropdown-menu" id="dropdown-menu3" role="menu">
                                 <div class="dropdown-content">
-                                    <a href="./log_update.html" class="dropdown-item has-text-left">
-                                        <span>メモを編集する</span>
-                                    </a>
+                                    <form action="{{ $memo_id }}/edit" method="POST">
+                                        @csrf
+                                        <button class="dropdown-item has-text-left" style="background: none; border: 0px; white-space: normal;">メモを編集する</button>
+                                    </form>
                                     <hr class="dropdown-divider">
                                     <a id="delete_memo" href="#" class="dropdown-item has-text-left">
                                         <span class="has-text-danger">メモを削除する</span>

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ asset('css/app.css') }}">
-    <title>メモ記録 EngineerStack</title>
+    <title>メモ編集 EngineerStack</title>
 </head>
 <body>
     <section class="header">
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <input class="input is-success" type="text" placeholder="キーワードを入力">
+                        <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                         <span class="icon is-small is-left">
                             <i class="fas fa-search"></i>
                         </span>
@@ -33,7 +33,7 @@
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
-                                <i class="fas fa-pen"></i><strong>記録</strong>
+                                <strong>記録</strong>
                             </a>
                             <form action="{{ route('logout') }}" method="POST">
                                 @csrf
@@ -46,34 +46,25 @@
         </nav>
     </section>
     <section class="content">
-        <div class="input-memo p-5">
+        <div class="form p-5">
             <div class="columns">
                 <div class="column"></div>
                 <div class="column is-three-fifths">
                     <div class="title mt-5">
-                        <h4 class="is-size-4">メモをとる</h4>
+                        <h4 class="is-size-4">メモを編集する</h4>
                     </div>
-                    <form action="{{ route('memos.store') }}" method="POST">
-                        @csrf
-                        <div class="errors">
-                            @if ($errors->any())
-                                <div class="has-text-danger">
-                                    <ul>
-                                        @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
-                                        @endforeach
-                                    </ul>
-                                </div>
-                            @endif
-                        </div>
+                    <form action="{{ route('memos.update')}}" method="POST">
+                        @csrf 
+                        <input type="hidden" id="memo_data" name="memo_data">
+                        <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                         <div class="field">
-                            <label for="comment">カテゴリ<br><span class="has-text-danger">*必須 最大5個 1カテゴリ30文字まで<br>半角カンマ「,」で区切って入力</span></label><br>
+                            <label for="comment">カテゴリ<br><span class="has-text-danger">*必須 最大5個 1カテゴリ30文字まで</span></label><br>
                             <span class="has-text-primary" id="count_category">残り5個入力可能</span>
-                            <span class="is-primary" id="disp_category"></span>
+                            <span id="disp_category"></span>
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input type="text" name="categories" class="input is-success" id="category" placeholder="カテゴリ1, カテゴリ2, カテゴリ3,...">
+                                        <input id="category" type="text" class="input is-success" placeholder="タイトル" value="MVCでわからなかったところ, php, Laravel, つまづき, MVC">
                                     </div>
                                 </div>
                             </div>
@@ -84,20 +75,17 @@
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input type="text" name="title" id="title" class="input is-success" placeholder="タイトルを入力" maxlength="100">
+                                        <input type="text" id="title" class="input is-success" placeholder="タイトル" value="{{ $memo->title }}">
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="editor_field">
-                            <label for="editor">コンテンツ<br><span>*任意</span></label>
-                            <div class="editor_wrapper p-5">
-                                <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
-                                <input type="hidden" id="memo_data" name="memo_data" value="{{ $article->content ?? "" }}">
-                            </div>
+                        <div class="memo">
+                            <label for="editorjs">メモ<br><span class="has-text-danger">*必須</span></label>
+                            <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
                         </div>
                         <button id="post_memo" class="button is-primary m-2">
-                            <p class="is-size-4"><i class="fas fa-save"></i>保存</p>
+                            <i class="far fa-edit"></i>更新
                         </button>
                     </form>
                 </div>
@@ -130,9 +118,13 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
     <script>
         $(function() {
+            let memoData = @json($memo_data);
+            memoData = JSON.parse(memoData);
+
             const editor = new EditorJS({
                 minHeight: 50,
-                holder: 'editorjs'
+                holder: 'editorjs',
+                data: memoData
             });
 
             $("#post_memo").click(function() {

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -85,7 +85,13 @@
                                 <span class="tag"><i class="fas fa-tape"></i>MVC</span>
                             </div><br>
                             <div class="title">
-                                <h4 class="is-size-5 has-text-weight-bold has-text-link">{{ $memo->title }}</h4>
+                                <form action="{{ route('memos.show') }}" method="POST">
+                                    @csrf 
+                                    <input type="hidden" name="memo_id" value="{{ $memo->id }}">
+                                    <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
+                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ $memo->title }}" type="submit"
+                                    style="background: none; border: 0px; white-space: normal;">
+                                </form>
                             </div>
                             <div id="data_{{ $loop->index }}">
                             </div><br>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,11 +19,12 @@ Route::prefix('memos')->group(function () {
     Route::get('create', [MemoController::class, 'create'])->name('memos.create');
     Route::post('store', [MemoController::class, 'store'])->name('memos.store');
     Route::post('{memo_id}/edit', [MemoController::class, 'edit'])->name('memos.edit');
-    Route::post('{memo_id}/update', [MemoController::class, 'update'])->name('memos.update');
+    Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');
     })->name('memos.get.input');
+    Route::post('show', [MemoController::class, 'show'])->name('memos.show');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
edit_memo.blade.phpを新規作成。
メモを記録→メモ詳細画面→メモ編集画面→メモ詳細画面...
または、
ホーム画面→メモ詳細画面→メモ編集画面→...
という画面遷移と機能を実装しました。
新たに追加したメモ編集画面のスクショです↓
![スクリーンショット 2021-11-04 210113](https://user-images.githubusercontent.com/42739038/140310122-008a8700-c3e8-4043-82c2-5d56f8ab5ceb.png)
![スクリーンショット 2021-11-04 210138](https://user-images.githubusercontent.com/42739038/140310124-c638af61-d1f9-46d5-bd10-859a2fb2f1c7.png)

