### PR TITLE
カテゴリの読み込み処理を実装。

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -14,6 +14,7 @@ class CategoryController extends Controller
 
     public function __construct(CategoryService $category_service)
     {
+        $this->middleware('auth');
         $this->category = $category_service;
     }
 

--- a/app/Http/Controllers/CategoryMemosController.php
+++ b/app/Http/Controllers/CategoryMemosController.php
@@ -50,7 +50,11 @@ class CategoryMemosController extends Controller
      */
     public function store($memo_id, $category_id)
     {
-        CategoryMemo::store($memo_id, $category_id);
+        $is_exist = CategoryMemo::where('memo_id', $memo_id)
+                                ->where('category_id', $category_id)->exists();
+        if(!$is_exist) {
+            CategoryMemo::store($memo_id, $category_id);
+        }
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -79,11 +79,11 @@ class MemoController extends Controller
     {
         $memo_id = $id;
         $memo = Memo::find($memo_id);
+        $categories = Memo::find($memo_id)->categories->pluck('name');
         $this->checkOwner($memo_id);
         $memo_data = $memo['memo_data'];
         return view('EngineerStack.edit_memo'
-                , compact('memo', 'memo_data'));
-        
+                , compact('memo', 'memo_data', 'categories'));
     }
 
     /**
@@ -132,7 +132,7 @@ class MemoController extends Controller
         $this->checkOwner($memo_id);
         $title = Memo::find($memo_id)->title;
         //TODO: カテゴリ機能実装時に必ず修正。
-        $categories = "php, Laravel, MVC, EngineerStack";
+        $categories = Memo::find($memo_id)->categories->pluck('name');
         $memo_data = Memo::find($memo_id)->memo_data;
         return view('EngineerStack.detailed_memo',
                 compact('title', 'categories', 'memo_data', 'memo_id'));

--- a/app/Models/Memo.php
+++ b/app/Models/Memo.php
@@ -31,4 +31,16 @@ class Memo extends Model
 
         return $memo->id;
     }
+
+    public function categories()
+    {
+        return $this->hasManyThrough(
+            Category::class,
+            CategoryMemo::class,
+            'memo_id',
+            'id',
+            null,
+            'category_id'
+        );
+    }
 }

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -64,7 +64,7 @@
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input id="category" type="text" class="input is-success" placeholder="タイトル" value="MVCでわからなかったところ, php, Laravel, つまづき, MVC">
+                                        <input id="category" type="text" class="input is-success" placeholder="カテゴリ">
                                     </div>
                                 </div>
                             </div>
@@ -120,6 +120,8 @@
         $(function() {
             let memoData = @json($memo_data);
             memoData = JSON.parse(memoData);
+            let categories = @json($categories);
+            $('#category').val(categories);
 
             const editor = new EditorJS({
                 minHeight: 50,

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -57,32 +57,20 @@
             <div class="columns">
                 <div class="column is-2">
                     <div class="category p-5">
-                        <span class="tag"><i class="fas fa-tape"></i>php</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>Laravel</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>SQL</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>MVC</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>CRUD</span><br>
-                        <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>悩んだ点</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>解決策</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>javascript</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>qiita</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>zenn</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>気づき</span><br>
-                        <span class="tag"><i class="fas fa-tape"></i>アイデア</span><br>
+                        @foreach($memos as $memo)
+                            @foreach($memo->categories->pluck('name') as $category)
+                                <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span><br>
+                            @endforeach
+                        @endforeach
                     </div>
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
                         <div class="memo column is-5 box m-3">
                             <div class="category">
-                                <span class="tag is-primary"><i class="fas fa-tape"></i>つまづきポイント</span>
-                                <span class="tag"><i class="fas fa-tape"></i>ログ</span>
-                                <span class="tag"><i class="fas fa-tape"></i>思考プロセス</span>
-                                <span class="tag"><i class="fas fa-tape"></i>php</span>
-                                <span class="tag"><i class="fas fa-tape"></i>Laravel</span>
-                                <span class="tag"><i class="fas fa-tape"></i>MVC</span>
+                                @foreach($memo->categories->pluck('name') as $category)
+                                    <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span>
+                                @endforeach
                             </div><br>
                             <div class="title">
                                 <form action="{{ route('memos.show') }}" method="POST">


### PR DESCRIPTION
memoモデルにhasManyThroughメソッドを書くことで、中間テーブル(categoryMemos)を通じてメモからカテゴリを取得できるようになった。
ホーム画面にて取得したカテゴリをforeachで回して表示した。
ホーム画面のスクショです↓ ※この画面では、カテゴリが重複していますが現在は修正しています。
![スクリーンショット 2021-11-06 215624](https://user-images.githubusercontent.com/42739038/140610391-0259499a-f24e-499b-8667-0796de254d08.png)


