### PR TITLE
ホーム画面にて、カテゴリが重複していたので重複をはじくロジックを実装。

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -38,4 +38,16 @@ class CategoryController extends Controller
     {
         $this->category->insertCategoryMemos($categories, $memo_id);
     }
+
+    /**
+     * @param object $memos
+     * memoコレクション。
+     * @return object $categories
+     * categoryコレクション。
+     */
+    public function getCategories(object $memos)
+    {
+        $categories = $this->category->getCategories($memos);
+        return $categories;
+    }
 }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -7,9 +7,12 @@ use Illuminate\Http\Request;
 use App\Http\Requests\StoreMemoRequest;
 use App\Models\Memo;
 use App\Models\Category;
+use App\Services\MemoService;
 
 class MemoController extends Controller
 {
+    private $memo;
+
     /**
      * コンストラクタでmiddleware('auth');
      * を設定しているので、ログイン前では
@@ -17,9 +20,10 @@ class MemoController extends Controller
      * 
      * @return void
      */
-    public function __construct()
+    public function __construct(MemoService $memoService)
     {
         $this->middleware('auth');
+        $this->memo = $memoService;
     }
 
     /**
@@ -33,8 +37,12 @@ class MemoController extends Controller
         $user_id = Auth::id();
         //後でカテゴリーの参照とViewへの返却も実装
         $memos = Memo::where('user_id', $user_id)->get();
+        //TODO $memosがある時点で、$memo_dataいらないのでは？後で検討。
+        //他の関数でも変数の重複が見られるから、要検討。
+        $get_categories = app()->make('App\Http\Controllers\CategoryController');
+        $categories = $get_categories->getCategories($memos);
         $memo_data = Memo::where('user_id', $user_id)->get('memo_data');
-        return view('EngineerStack.home', compact('memos', 'memo_data'));
+        return view('EngineerStack.home', compact('memos', 'memo_data', 'categories'));
     }
 
     /**

--- a/app/Models/Memo.php
+++ b/app/Models/Memo.php
@@ -44,17 +44,15 @@ class Memo extends Model
     }
 
     /**
-     * 
-     * 
+     * Memoレコードに紐づくCategoryレコードを返す関数。
+     * @return mixed Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function categories()
     {
-        return $this->hasManyThrough(
+        return $this->belongsToMany(
             Category::class,
             CategoryMemo::class,
             'memo_id',
-            'id',
-            null,
             'category_id'
         );
     }

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -10,7 +10,7 @@
          * @param string: $categories
          * @return array: $categories_arr
          */
-        public function strToArr($categories)
+        public function strToArr(string $categories)
         {
             $separater = ",";
             $categories_arr = explode($separater, $categories);
@@ -45,5 +45,25 @@
                 $insert_category_memos = app()->make('App\Http\Controllers\CategoryMemosController');
                 $insert_category_memos->store($memo_id, $category_id);
             }
+        }
+
+        /**
+         * この関数はmemoコレクションを受け取ってmemoコレクションに対応する
+         * categoryを重複を許さないコレクションとして返す。
+         * @param object $memos
+         * memoコレクション。
+         * @return object $unique_categories
+         * 一意なcategoryコレクション。
+         */
+        public function getCategories(object $memos) 
+        {
+            $category_collection = collect();
+            
+            foreach($memos as $memo) {
+                $to_collection = collect($memo->categories);
+                $category_collection = $category_collection->concat($to_collection);
+            }
+            $unique_categories = $category_collection->unique('name')->pluck('name');
+            return $unique_categories;
         }
     }

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -1,0 +1,10 @@
+<?php
+    namespace App\Services;
+
+    use App\Models\Memo;
+    use App\Models\Category;
+    use App\Models\CategoryMemos;
+
+    class MemoService {
+        
+    }

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -57,10 +57,8 @@
             <div class="columns">
                 <div class="column is-2">
                     <div class="category p-5">
-                        @foreach($memos as $memo)
-                            @foreach($memo->categories->pluck('name') as $category)
-                                <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span><br>
-                            @endforeach
+                        @foreach($categories as $category)
+                            <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span><br>
                         @endforeach
                     </div>
                 </div>


### PR DESCRIPTION
CategoryServiceに重複をはじくロジックを実装。
写真1枚目→2枚目のように重複表示を直しました。
レビューよろしくお願いします。
![スクリーンショット 2021-11-09 204903](https://user-images.githubusercontent.com/42739038/140926298-1e32020f-db7f-4c01-84fd-f251bc511974.png)
![スクリーンショット 2021-11-09 214154](https://user-images.githubusercontent.com/42739038/140926309-0a9c26b9-9f4c-4968-8e15-f0c18244d2ab.png)
