### PR TITLE
メモ記録画面で入力された値へのformRequestを実装。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -58,7 +58,7 @@ class MemoController extends Controller
      * TODO 後でStoreMemoRequestに型を書き換えて、フォームバリデーションを
      * 実装
      */
-    public function store(Request $request)
+    public function store(StoreMemoRequest $request)
     {
         $user_id = Auth::id();
         $categories = $request->input('categories');

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -65,8 +65,7 @@ class MemoController extends Controller
         $title = $request->input('title');
         $memo_data = $request->input('memo_data');
         $memo_id = Memo::store($user_id, $title, $memo_data);
-        $insert_categories = app()->make('App\Http\Controllers\CategoryController');
-        $insert_categories->store($categories, $memo_id);
+        $insert_categories = $this->memo->insertCategories($categories, $memo_id);
         return view('EngineerStack.detailed_memo', compact('memo_data',
                                             'title', 'categories', 'memo_id'));
     }
@@ -85,7 +84,7 @@ class MemoController extends Controller
         $memo_id = $id;
         $memo = Memo::find($memo_id);
         $categories = Memo::find($memo_id)->categories->pluck('name');
-        $this->checkOwner($memo_id);
+        $this->memo->checkOwner($memo_id);
         $memo_data = $memo['memo_data'];
         return view('EngineerStack.edit_memo'
                 , compact('memo', 'memo_data', 'categories'));
@@ -107,7 +106,7 @@ class MemoController extends Controller
         $memo_id = $request->input('memo_id');
         $memo_data = $request->input('memo_data');
         $title = $request->input('title');
-        $this->checkOwner($memo_id);
+        $this->memo->checkOwner($memo_id);
         Memo::where('id', $memo_id)
                     ->update(['memo_data' => $memo_data, 'title' => $title]);
         $title = Memo::find($memo_id)->title;
@@ -115,7 +114,6 @@ class MemoController extends Controller
         $memo_data = Memo::find($memo_id)->memo_data;
         return view('EngineerStack.detailed_memo'
                 , compact('title', 'categories', 'memo_data', 'memo_id'));
-        
     }
 
     /** 
@@ -132,7 +130,7 @@ class MemoController extends Controller
     {
         $memo_id = $request->input('memo_id');
         $memo_data = $request->input('memo_data');
-        $this->checkOwner($memo_id);
+        $this->memo->checkOwner($memo_id);
         $title = Memo::find($memo_id)->title;
         $categories = Memo::find($memo_id)->categories->pluck('name');
         $memo_data = Memo::find($memo_id)->memo_data;
@@ -152,27 +150,8 @@ class MemoController extends Controller
     public function destroy(Request $request)
     {
         $memo_id = $request->input('memo_id');
-        $this->checkOwner($memo_id);
+        $this->memo->checkOwner($memo_id);
         Memo::destroy($memo_id);
         return redirect()->route('memos.deleted');
-    }
-
-    /**
-     * この関数はメモに対して何らの処理を加える際に、
-     * メモの所有者以外のアカウントがメモに処理を加え
-     * ることを防ぐ処理を担当しています。
-     * 
-     * @param int $memo_id
-     * メモの主キーです。
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
-     * ホーム画面を返します。
-     */
-    public function checkOwner(int $memo_id)
-    {
-        $memo_owner = Memo::find($memo_id)->user_id;
-        
-        if($memo_owner != Auth::id()) {
-            return redirect()->route('dashboard');
-        }
     }
 }

--- a/app/Http/Requests/StoreMemoRequest.php
+++ b/app/Http/Requests/StoreMemoRequest.php
@@ -7,7 +7,8 @@ use Illuminate\Foundation\Http\FormRequest;
 class StoreMemoRequest extends FormRequest
 {
     /**
-     * Determine if the user is authorized to make this request.
+     * 現在認証されているユーザーがリクエストによって
+     * 表されるアクションを実行できるか
      *
      * @return bool
      */
@@ -17,25 +18,44 @@ class StoreMemoRequest extends FormRequest
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * リクエストに適用するルール
      *
      * @return array
      */
     public function rules()
     {
         return [
+            'categories' => 'required|max:154',
+            'categories_count' => 'required|regex:/[1-5]/',
             'title' => 'required|max:100',
-            'memo' => 'json',
-            'memo_count' => 'max:100'
+            'memo_count' => 'required|max:3000',
         ];
     }
 
+    /**
+     * バリデーションエラーのカスタムメッセージ
+     *
+     * @return array
+     */
     public function messages()
     {
         return [
             'title.max:100' => 'カテゴリは100文字以内に収めてください。',
-            'categories.required' => 'カテゴリは必ず1つの入力が必要です',
-            'categories.*.max:30' => '各カテゴリは最大30文字です'
+            'categories_count.regex' => 'カテゴリの最大数は5つです。'
+        ];
+    }
+
+    /**
+     * バリデーションエラーのカスタム属性の取得
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'title' => 'メモのタイトル',
+            'memo_count' => 'メモの文字数',
+            'categories' => 'カテゴリ'
         ];
     }
 }

--- a/app/Http/Requests/StoreMemoRequest.php
+++ b/app/Http/Requests/StoreMemoRequest.php
@@ -24,16 +24,16 @@ class StoreMemoRequest extends FormRequest
     public function rules()
     {
         return [
-            'categories' => 'required|array',
-            'categories.*' => 'nullable|max:30',
             'title' => 'required|max:100',
-            'memo' => 'json'
+            'memo' => 'json',
+            'memo_count' => 'max:100'
         ];
     }
 
     public function messages()
     {
         return [
+            'title.max:100' => 'カテゴリは100文字以内に収めてください。',
             'categories.required' => 'カテゴリは必ず1つの入力が必要です',
             'categories.*.max:30' => '各カテゴリは最大30文字です'
         ];

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -6,5 +6,37 @@
     use App\Models\CategoryMemos;
 
     class MemoService {
-        
+        /**
+         * categoriesテーブルにカテゴリを挿入
+         * 
+         * @param string $categories
+         * メモ記録画面で入力されたカテゴリ文字列
+         * @param int $memo_id
+         * memoレコードのid。
+         * @return void
+         */
+        public function insertCategories(string $categories, int $memo_id)
+        {
+            $insert_categories = app()->make('App\Http\Controllers\CategoryController');
+            $insert_categories->store($categories, $memo_id);
+        }
+
+        /**
+         * この関数はメモに対して何らの処理を加える際に、
+         * メモの所有者以外のアカウントがメモに処理を加え
+         * ることを防ぐ処理を担当しています。
+         * 
+         * @param int $memo_id
+         * メモの主キーです。
+         * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+         * ホーム画面へリダイレクト。
+         */
+        public function checkOwner(int $memo_id)
+        {
+            $memo_owner = Memo::find($memo_id)->user_id;
+            
+            if($memo_owner != Auth::id()) {
+                return redirect()->route('dashboard');
+            }
+        }
     }

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -60,7 +60,7 @@
                     <i class="fas fa-tape"></i><span id="categories"></span>
                 </div>
                 <div class="memo mt-5">
-                    <div id="editorjs"></div>
+                    <div id="editorjs" style="overflow-wrap: break-word;"></div>
                     <div class="settings has-text-right mt-4">
                         <div class="dropdown">
                             <div class="dropdown-trigger">

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -79,10 +79,10 @@
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>
                             </div>
-                            <div id="data_{{ $loop->index }}">
+                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
                             </div><br>
                             <div class="post-time">
-                                <p>{{ $memo->created_at->format('Y年m月d日投稿') }}</p>
+                                <p>{{ $memo->created_at->diffForHumans() }}</p>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -90,9 +90,11 @@
                             </div>
                         </div>
                         <div class="editor_field">
-                            <label for="editor">メモ<br><span class="has-text-danger">*必須</span></label>
+                            <label for="editor">メモ<br><span class="has-text-danger">*必須 4000文字以内</span></label>
+                            <div id="editorjsCnt"></div>
                             <div class="editor_wrapper p-5">
                                 <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
+                                <input type="hidden" id="memo_count" name="memo_count">
                                 <input type="hidden" id="memo_data" name="memo_data" value="{{ $article->content ?? "" }}">
                             </div>
                         </div>
@@ -132,8 +134,22 @@
         $(function() {
             const editor = new EditorJS({
                 minHeight: 50,
-                holder: 'editorjs'
+                holder: 'editorjs',
+                onChange: () => {
+                    let myCode = $('#editorjs').html();
+                    let cleanCode = myCode.replace(/<(?:.|\n)*?>/gm, '').replace(/(\r\n|\n|\r)/gm,"").replace('&nbsp;','');
+                    let numChars = cleanCode.trim().length - 52;
+                    if(numChars < 0) {
+                        numChars = 0;
+                    }
+                    $('#editorjsCnt').text(numChars + "文字入力されています。");
+                    $('#memo_count').val(numChars);
+                    console.log(numChars);
+                }
             });
+
+            
+
 
             $("#post_memo").click(function() {
                 editor.save().then((outputData) => {

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -67,13 +67,13 @@
                             @endif
                         </div>
                         <div class="field">
-                            <label for="comment">カテゴリ<br><span class="has-text-danger">*必須 最大5個 1カテゴリ30文字まで<br>半角カンマ「,」で区切って入力</span></label><br>
+                            <label for="comment">カテゴリ<br><span class="has-text-danger">*必須 最大5個 合計150文字まで<br>半角カンマ「,」で区切って入力</span></label><br>
                             <span class="has-text-primary" id="count_category">残り5個入力可能</span>
                             <span class="is-primary" id="disp_category"></span>
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input type="text" name="categories" class="input is-success" id="category" placeholder="カテゴリ1, カテゴリ2, カテゴリ3,...">
+                                        <input type="text" name="categories" class="input is-success" id="category" placeholder="カテゴリ1, カテゴリ2, カテゴリ3,..." maxlength="154" required autofocus>
                                     </div>
                                 </div>
                             </div>
@@ -84,16 +84,17 @@
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input type="text" name="title" id="title" class="input is-success" placeholder="タイトルを入力" maxlength="100">
+                                        <input type="text" name="title" id="title" class="input is-success" placeholder="タイトルを入力" maxlength="100" required>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div class="editor_field">
-                            <label for="editor">メモ<br><span class="has-text-danger">*必須 4000文字以内</span></label>
+                            <label for="editor">メモ<br><span class="has-text-danger">*必須 3000文字以内</span></label>
                             <div id="editorjsCnt"></div>
                             <div class="editor_wrapper p-5">
                                 <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
+                                <input type="hidden" id="categories_count" name="categories_count">
                                 <input type="hidden" id="memo_count" name="memo_count">
                                 <input type="hidden" id="memo_data" name="memo_data" value="{{ $article->content ?? "" }}">
                             </div>
@@ -138,13 +139,13 @@
                 onChange: () => {
                     let myCode = $('#editorjs').html();
                     let cleanCode = myCode.replace(/<(?:.|\n)*?>/gm, '').replace(/(\r\n|\n|\r)/gm,"").replace('&nbsp;','');
-                    let numChars = cleanCode.trim().length - 52;
+                    cleanCode = cleanCode.slice(0, -52);
+                    let numChars = cleanCode.length;
                     if(numChars < 0) {
                         numChars = 0;
                     }
                     $('#editorjsCnt').text(numChars + "文字入力されています。");
-                    $('#memo_count').val(numChars);
-                    console.log(numChars);
+                    $('#memo_count').val(cleanCode);
                 }
             });
 
@@ -154,9 +155,8 @@
             $("#post_memo").click(function() {
                 editor.save().then((outputData) => {
                     $('#memo_data').val(JSON.stringify(outputData));
-                    console.log('Article data: ', outputData);
                 }).catch((error) => {
-                    console.log('Saving failed: ', error);
+
                 });
             });
 
@@ -164,10 +164,13 @@
                 const separator = ",";
                 let inputText = $(this).val();
                 let textToArray = separateText(separator, inputText);
-                let array = checkElement(textToArray);
+                //let array = checkElement(textToArray);
                 let dispText = arrayToText(textToArray);
-                let tags = pushTag(array);
+                let tags = pushTag(textToArray);
                 $("#disp_category").html(tags);
+                let arrayLength = textToArray.length;
+                console.log(arrayLength);
+                $('#categories_count').val(arrayLength);
             });
 
             $("#title").keyup(function() {
@@ -208,26 +211,26 @@
             }
         }
 
-        function checkElement(array) {
-            const id = "#count_category";
+        // function checkElement(array) {
+        //     const id = "#count_category";
 
-            for(let i=0;i<array.length;i++) {
-                if(array[i] === '' || array[i].length === 0) {
-                    array.splice(i, 1);
-                } else if(array[i].length > 30) {
-                    const isNormal = false;
-                    const text = "カテゴリが30文字を超えています!";
-                    changeText(id, text);
-                    changeClass(id, isNormal);
-                    return;
-                } else {
-                    const isNormal = true;
-                    changeClass(id, isNormal);
-                }
-            }
-            countCategory(array);
-            return array;
-        }
+        //     for(let i=0;i<array.length;i++) {
+        //         if(array[i] === '' || array[i].length === 0) {
+        //             array.splice(i, 1);
+        //         } else if(array[i].length > 30) {
+        //             const isNormal = false;
+        //             const text = "カテゴリが30文字を超えています!";
+        //             changeText(id, text);
+        //             changeClass(id, isNormal);
+        //             return;
+        //         } else {
+        //             const isNormal = true;
+        //             changeClass(id, isNormal);
+        //         }
+        //     }
+        //     countCategory(array);
+        //     return array;
+        // }
 
         function createElement(tag, type, text) {
             let element = $(`<${tag}>`, {class:type, text: text});


### PR DESCRIPTION
editor.jsで入力されたメモ部分の文字数をカウントしてバリデーションをかけました。
タイトルには、100文字以内必須のバリデーションをかけました。
カテゴリには、最大5つのカテゴリ、文字数は最大で150文字のバリデーションをかけました。
本来は別のブランチでやるべきですが、MemoControllerのビジネスロジックをMemoServiceに
移しました(メモの所有者以外がメモにアクセスした場合のリダイレクト処理)。
ホーム画面とメモ詳細画面で、メモ表示部分の文字列が要素を突き抜けてしまって表示が乱れていたので
over-flow属性を追加する修正を行いました。
よろしくお願いします。