### PR TITLE
キーワードでのメモ検索機能を実装。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -163,9 +163,13 @@ class MemoController extends Controller
     public function searchTitle(Request $request)
     {
         $user_id = Auth::id();
+        $memos = Memo::where('user_id', $user_id)->get();
         $search_word = $request->input('search_word');
-        $memos = Memo::where('title', 'LIKE', "%$search_word%")
-            ->where('user_id', $user_id)->paginate(6);
+        $search_title = Memo::where('title', 'LIKE', "%$search_word%")
+            ->where('user_id', $user_id)->get();
+        $search_memo = Memo::whereJsonContains("memo_data->blocks->data->text", "%$search_word%")->get();
+        dd($search_memo);
+        die;
         $categories = $this->memo->getCategories($memos);
         return view('EngineerStack.search_result', 
                 compact('search_word', 'memos', 'categories'));

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -41,7 +41,8 @@ class MemoController extends Controller
         $memos = Memo::where('user_id', $user_id)->paginate(6);
         //TODO $memosがある時点で、$memo_dataいらないのでは？後で検討。
         //他の関数でも変数の重複が見られるから、要検討。
-        $categories = $this->memo->getCategories($memos);
+        $posted_memos = Memo::where('user_id', $user_id)->get();
+        $categories = $this->memo->getCategories($posted_memos);
         return view('EngineerStack.home', compact('memos', 'categories'));
     }
 
@@ -164,6 +165,7 @@ class MemoController extends Controller
     {
         $user_id = Auth::id();
         $memos = Memo::where('user_id', $user_id)->get();
+        $categories = $this->memo->getCategories($memos);
         $search_word = $request->input('search_word');
         $search_title = Memo::where('title', 'LIKE', "%$search_word%")
             ->where('user_id', $user_id)->get();
@@ -192,7 +194,6 @@ class MemoController extends Controller
 
         $hit_memos = $hit_memos->concat($search_title);
         $hit_memos = $hit_memos->unique('memo_data');
-        $categories = $this->memo->getCategories($memos);
         return view('EngineerStack.search_result', 
                 compact('search_word', 'hit_memos', 'categories'));
     }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -9,6 +9,7 @@ use App\Models\Memo;
 use App\Models\Category;
 use App\Services\MemoService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Pagination\Paginator;
 
 class MemoController extends Controller
 {
@@ -37,12 +38,11 @@ class MemoController extends Controller
     {
         $user_id = Auth::id();
         //後でカテゴリーの参照とViewへの返却も実装
-        $memos = Memo::where('user_id', $user_id)->get();
+        $memos = Memo::where('user_id', $user_id)->paginate(6);
         //TODO $memosがある時点で、$memo_dataいらないのでは？後で検討。
         //他の関数でも変数の重複が見られるから、要検討。
         $categories = $this->memo->getCategories($memos);
-        $memo_data = Memo::where('user_id', $user_id)->get('memo_data');
-        return view('EngineerStack.home', compact('memos', 'memo_data', 'categories'));
+        return view('EngineerStack.home', compact('memos', 'categories'));
     }
 
     /**
@@ -76,7 +76,6 @@ class MemoController extends Controller
             DB::rollback();
             return redirect()->route('dashboard');
         }
-        
     }
 
     /**
@@ -166,12 +165,10 @@ class MemoController extends Controller
         $user_id = Auth::id();
         $search_word = $request->input('search_word');
         $memos = Memo::where('title', 'LIKE', "%$search_word%")
-            ->where('memo_data', 'LIKE', "%$search_word%")
-            ->where('user_id', $user_id)->get();
-        $memo_data = $memos->pluck('memo_data');
+            ->where('user_id', $user_id)->paginate(6);
         $categories = $this->memo->getCategories($memos);
         return view('EngineerStack.search_result', 
-                compact('search_word', 'memos', 'memo_data', 'categories'));
+                compact('search_word', 'memos', 'categories'));
     }
 
     public function searchCategory(Request $request)
@@ -181,10 +178,9 @@ class MemoController extends Controller
         $search_word = $category;
         $posted_memo = Memo::where('user_id', $user_id)->get();
         $memos = $this->memo->getMemos($category);
-        $memo_data = $memos->pluck('memo_data');
         $categories = $this->memo->getCategories($posted_memo);
         return view('EngineerStack.search_result', 
-                compact('search_word', 'memos', 'memo_data', 'categories'));
+                compact('search_word', 'memos','categories'));
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -10,6 +10,7 @@ use App\Models\Category;
 use App\Services\MemoService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Pagination\Paginator;
+use Exception;
 
 class MemoController extends Controller
 {

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -162,53 +162,28 @@ class MemoController extends Controller
                 compact('title', 'categories', 'memo_data', 'memo_id'));
     }
 
-    public function searchTitle(Request $request)
+    /**
+     * この関数はキーワードでのメモ検索を担当しています。
+     * @param Illuminate\Http\Request $request
+     * $requestには、キーワード、現在のページ番号が入っています。
+     * @return Illuminate\View\View
+     * メモ検索結果を返します。
+     */
+    public function search(Request $request)
     {
-        $user_id = Auth::id();
-        $memos = Memo::where('user_id', $user_id)->get();
-        $categories = $this->memo->getCategories($memos);
-        $search_word = $request->input('search_word');
-        $search_title = Memo::where('title', 'LIKE', "%$search_word%")
-            ->where('user_id', $user_id)->get();
-        $search_memo = Memo::where("memo_data->blocks", 'LIKE', "%$search_word%")->pluck('memo_data');
-        $memo_count = count($search_memo);
-        $search_memo = json_decode($search_memo, true);
-        $hit_id = [];
-        for($index = 0; $index < $memo_count; $index++) {
-            $memo = $search_memo[$index];
-            $json_memo = json_decode($memo, true);
-            $block_count = count($json_memo['blocks']);
-            for($block = 0; $block < $block_count; $block++) {
-                if(strpos($json_memo['blocks'][$block]['data']['text'], $search_word) !== false) {
-                    $id = $json_memo['blocks'][$block]['id'];
-                    array_push($hit_id, $id);
-                }
-            }
-        }
-        
-        $hit_memos = collect();
-        $length = count($hit_id);
-        for($index = 0; $index < $length; $index++) {
-            $search_json = Memo::where("memo_data->blocks", 'LIKE', "%$hit_id[$index]%")->get();
-            $hit_memos = $hit_memos->concat($search_json);
-        }
-
-        $hit_memos = $hit_memos->concat($search_title);
-        $hit_memos = $hit_memos->unique('memo_data');
-        return view('EngineerStack.search_result', 
-                compact('search_word', 'hit_memos', 'categories'));
+        return $this->memo->search($request);
     }
 
+    /**
+     * この関数はカテゴリでのメモ検索を担当しています。
+     * @param Illuminate\Http\Request $request
+     * $requestには、カテゴリ名が入っています。
+     * @return Illuminate\View\View
+     * メモ検索結果を返します。
+     */
     public function searchCategory(Request $request)
     {
-        $user_id = Auth::id();
-        $category = $request->input('category');
-        $search_word = $category;
-        $posted_memo = Memo::where('user_id', $user_id)->get();
-        $hit_memos = $this->memo->getMemos($category);
-        $categories = $this->memo->getCategories($posted_memo);
-        return view('EngineerStack.search_result', 
-                compact('search_word', 'hit_memos','categories'));
+        return $this->memo->searchCategory($request);
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -161,7 +161,7 @@ class MemoController extends Controller
                 compact('title', 'categories', 'memo_data', 'memo_id'));
     }
 
-    public function search(Request $request)
+    public function searchTitle(Request $request)
     {
         $user_id = Auth::id();
         $search_word = $request->input('search_word');
@@ -170,6 +170,19 @@ class MemoController extends Controller
             ->where('user_id', $user_id)->get();
         $memo_data = $memos->pluck('memo_data');
         $categories = $this->memo->getCategories($memos);
+        return view('EngineerStack.search_result', 
+                compact('search_word', 'memos', 'memo_data', 'categories'));
+    }
+
+    public function searchCategory(Request $request)
+    {
+        $user_id = Auth::id();
+        $category = $request->input('category');
+        $search_word = $category;
+        $posted_memo = Memo::where('user_id', $user_id)->get();
+        $memos = $this->memo->getMemos($category);
+        $memo_data = $memos->pluck('memo_data');
+        $categories = $this->memo->getCategories($posted_memo);
         return view('EngineerStack.search_result', 
                 compact('search_word', 'memos', 'memo_data', 'categories'));
     }

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -4,7 +4,7 @@
     use Illuminate\Support\Facades\Auth;
     use App\Models\Memo;
     use App\Models\Category;
-    use App\Models\CategoryMemos;
+    use App\Models\CategoryMemo;
 
     class MemoService {
         /**
@@ -100,5 +100,18 @@
             $get_categories = app()->make('App\Http\Controllers\CategoryController');
             $categories = $get_categories->getCategories($memos);
             return $categories;
+        }
+
+        public function getMemos(string $category)
+        {
+            $memos = collect();
+            $category_id = Category::where('name', $category)->pluck('id');
+            $memo_ids = CategoryMemo::where('category_id', $category_id)->pluck('memo_id');
+            $memo_count = count($memo_ids);
+            for($index = 0; $index < $memo_count; $index++) {
+                $memo = Memo::where('id', $memo_ids[$index])->get();
+                $memos = $memos->concat($memo);
+            }
+            return $memos;
         }
     }

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -176,7 +176,7 @@
         public function searchCategory(Request $request)
         {
             $user_id = Auth::id();
-            $category = $request->input('category');
+            $category = $request->input('search_word');
             $search_word = $category;
             $posted_memo = Memo::where('user_id', $user_id)->get();
             $hit_memos = $this->getMemos($category);
@@ -185,8 +185,8 @@
             if(empty($current_page)) {
                 $current_page = 1;
             }
-            $memos = $hit_memos->forPage($current_page, 1);
-            $total_pages = (int)ceil(count($hit_memos)/1);
+            $memos = $hit_memos->forPage($current_page, 6);
+            $total_pages = (int)ceil(count($hit_memos)/6);
             return view('EngineerStack.search_result', 
                     compact('search_word', 'memos','categories', 'current_page', 'total_pages'));
         }

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -1,6 +1,7 @@
 <?php
     namespace App\Services;
 
+    use Illuminate\Http\Request;
     use Illuminate\Support\Facades\Auth;
     use App\Models\Memo;
     use App\Models\Category;
@@ -113,5 +114,80 @@
                 $memos = $memos->concat($memo);
             }
             return $memos;
+        }
+
+        /**
+         * この関数はキーワードでのメモ検索を担当しています。
+         * @param Illuminate\Http\Request $request
+         * $requestには、キーワード、現在のページ番号が入っています。
+         * @return Illuminate\View\View
+         * メモ検索結果を返します。
+         */
+        public function search(Request $request)
+        {
+            $user_id = Auth::id();
+            $memos = Memo::where('user_id', $user_id)->get();
+            $categories = $this->getCategories($memos);
+            $search_word = $request->input('search_word');
+            $search_title = Memo::where('title', 'LIKE', "%$search_word%")
+                ->where('user_id', $user_id)->get();
+            $search_memo = Memo::where("memo_data->blocks", 'LIKE', "%$search_word%")->pluck('memo_data');
+            $memo_count = count($search_memo);
+            $search_memo = json_decode($search_memo, true);
+            $hit_id = [];
+            for($index = 0; $index < $memo_count; $index++) {
+                $memo = $search_memo[$index];
+                $json_memo = json_decode($memo, true);
+                $block_count = count($json_memo['blocks']);
+                for($block = 0; $block < $block_count; $block++) {
+                    if(strpos($json_memo['blocks'][$block]['data']['text'], $search_word) !== false) {
+                        $id = $json_memo['blocks'][$block]['id'];
+                        array_push($hit_id, $id);
+                    }
+                }
+            }
+            
+            $hit_memos = collect();
+            $length = count($hit_id);
+            for($index = 0; $index < $length; $index++) {
+                $search_json = Memo::where("memo_data->blocks", 'LIKE', "%$hit_id[$index]%")->get();
+                $hit_memos = $hit_memos->concat($search_json);
+            }
+
+            $hit_memos = $hit_memos->concat($search_title);
+            $hit_memos = $hit_memos->unique('memo_data');
+            $current_page = $request->input('page');
+            if(empty($current_page)) {
+                $current_page = 1;
+            }
+            $memos = $hit_memos->forPage($current_page, 6);
+            $total_pages = (int)ceil(count($hit_memos)/6);
+            return view('EngineerStack.search_result', 
+                    compact('search_word', 'memos', 'categories', 'current_page', 'total_pages'));
+        }
+
+        /**
+         * この関数はカテゴリでのメモ検索を担当しています。
+         * @param Illuminate\Http\Request $request
+         * $requestには、カテゴリ名が入っています。
+         * @return Illuminate\View\View
+         * メモ検索結果を返します。
+         */
+        public function searchCategory(Request $request)
+        {
+            $user_id = Auth::id();
+            $category = $request->input('category');
+            $search_word = $category;
+            $posted_memo = Memo::where('user_id', $user_id)->get();
+            $hit_memos = $this->getMemos($category);
+            $categories = $this->getCategories($posted_memo);
+            $current_page = $request->input('page');
+            if(empty($current_page)) {
+                $current_page = 1;
+            }
+            $memos = $hit_memos->forPage($current_page, 1);
+            $total_pages = (int)ceil(count($hit_memos)/1);
+            return view('EngineerStack.search_result', 
+                    compact('search_word', 'memos','categories', 'current_page', 'total_pages'));
         }
     }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -14,11 +14,6 @@ class CategoryFactory extends Factory
      */
     protected $model = Category::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
     public function definition()
     {
         return [

--- a/database/factories/MemoFactory.php
+++ b/database/factories/MemoFactory.php
@@ -2,23 +2,18 @@
 
 namespace Database\Factories;
 
-use App\Models\Content;
+use App\Models\Memo;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-class ContentFactory extends Factory
+class MemoFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var string
      */
-    protected $model = Content::class;
+    protected $model = Memo::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array
-     */
     public function definition()
     {
         return [

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -16,10 +16,13 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
-                        <span class="icon is-small is-left">
-                            <i class="fas fa-search"></i>
-                        </span>
+                        <form action="{{ route('memos.search') }}" method="GET">
+                            @csrf 
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-search"></i>
+                            </span>
+                        </form>
                     </div>
                 </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -16,10 +16,13 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <input class="input is-success" type="text" placeholder="キーワードを入力">
-                        <span class="icon is-small is-left">
-                            <i class="fas fa-search"></i>
-                        </span>
+                        <form action="{{ route('memos.search') }}" method="GET">
+                            @csrf 
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-search"></i>
+                            </span>
+                        </form>
                     </div>
                 </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -16,10 +16,13 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
-                        <span class="icon is-small is-left">
-                            <i class="fas fa-search"></i>
-                        </span>
+                        <form action="{{ route('memos.search') }}" method="GET">
+                            @csrf 
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-search"></i>
+                            </span>
+                        </form>
                     </div>
                 </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -71,7 +71,7 @@
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
@@ -81,7 +81,7 @@
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
-                                    <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
+                                    <input type="hidden" name="memo_data" value="{{ $memo->memo_data }}">
                                     <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 15) }}" type="submit"
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search.title') }}" method="POST">
+                        <form action="{{ route('memos.search.title') }}" method="GET">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">
@@ -61,7 +61,7 @@
                 <div class="column is-2">
                     <div class="category p-5">
                         @foreach($categories as $category)
-                            <form action="{{ route('memos.search.category') }}" method="POST">
+                            <form action="{{ route('memos.search.category') }}" method="">
                                 @csrf 
                                 <input type="hidden" name="category" value="{{ $category }}">
                                 <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span><br></button>
@@ -97,13 +97,26 @@
             </div>
             <div class="columns">
                 <div class="column">
-                    <div class="paging has-text-centered mt-5">
-                        <a href="">1</a>
-                        <a href="">2</a>
-                        <a href="">3</a>
-                        <a href="">4</a>
-                        <a class="ml-5" href="">次へ</a>
-                    </div>
+                    <nav class="pagination is-centered" role="navigation" aria-label="pagination">
+                        <ul class="pagination-list">
+                            {{-- ページネーションが正しく動作していない。 --}}
+                            @if($memos->currentPage() == 1)
+                                @if($memos->currentPage() == $memos->lastPage())
+                                    <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                                @else 
+                                    <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                                    <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
+                                @endif
+                            @elseif($memos->currentPage() == $memos->lastPage())
+                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                            @else 
+                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                                <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
+                            @endif
+                        </ul>
+                    </nav>
                 </div>
             </div>
         </section>
@@ -135,12 +148,11 @@
     <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
     <script>
         $(function () {
-            let memoData = @json($memo_data);
-            let memoLength = JSON.parse(JSON.stringify(memoData)).length;
+            let memoData = @json($memos->pluck('memo_data') ?? []);
+            let memoLength = memoData.length;
 
             for(let index=0;index<memoLength;index++) {
                 let data = memoData[index];
-                data = data.memo_data;
                 data = JSON.parse(data);
                 let post_time = data.time;
                 post_time = new Date(post_time);

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -61,10 +61,10 @@
                 <div class="column is-2">
                     <div class="category p-5">
                         @foreach($categories as $category)
-                            <form action="{{ route('memos.search.category') }}" method="">
+                            <form action="{{ route('memos.search.category') }}">
                                 @csrf 
                                 <input type="hidden" name="category" value="{{ $category }}">
-                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span><br></button>
+                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
                             </form>
                         @endforeach
                     </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search.title') }}" method="GET">
+                        <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -82,7 +82,7 @@
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                     <input type="hidden" name="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 15) }}" type="submit"
+                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 100) }}" type="submit"
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>
                             </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -63,7 +63,7 @@
                         @foreach($categories as $category)
                             <form action="{{ route('memos.search.category') }}">
                                 @csrf 
-                                <input type="hidden" name="category" value="{{ $category }}">
+                                <input type="hidden" name="search_word" value="{{ $category }}">
                                 <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
                             </form>
                         @endforeach

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="POST">
+                        <form action="{{ route('memos.search.title') }}" method="POST">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">
@@ -61,7 +61,11 @@
                 <div class="column is-2">
                     <div class="category p-5">
                         @foreach($categories as $category)
-                            <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span><br>
+                            <form action="{{ route('memos.search.category') }}" method="POST">
+                                @csrf 
+                                <input type="hidden" name="category" value="{{ $category }}">
+                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span><br></button>
+                            </form>
                         @endforeach
                     </div>
                 </div>
@@ -70,7 +74,7 @@
                         <div class="memo column is-5 box m-3">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
-                                    <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span>
+                                    <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                 @endforeach
                             </div><br>
                             <div class="title">
@@ -78,7 +82,7 @@
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                     <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ $memo->title }}" type="submit"
+                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 15) }}" type="submit"
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>
                             </div>

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -96,7 +96,7 @@
                                 <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
                                 <input type="hidden" id="categories_count" name="categories_count">
                                 <input type="hidden" id="memo_count" name="memo_count">
-                                <input type="hidden" id="memo_data" name="memo_data" value="{{ $article->content ?? "" }}">
+                                <input type="hidden" id="memo_data" name="memo_data" value="">
                             </div>
                         </div>
                         <button id="post_memo" class="button is-primary m-2">

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -65,9 +65,9 @@
                                 @csrf 
                                 <input type="hidden" name="category" value="{{ $category }}">
                                 @if ($category == $search_word)
-                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span></button>
+                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
                                 @else 
-                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span></button>
+                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
                                 @endif
                             </form>
                         @endforeach

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="POST">
+                        <form action="{{ route('memos.search.title') }}" method="POST">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">
@@ -50,27 +50,43 @@
     </section>
     @if($memos->isEmpty())
         <section class="content">
-            <p>{{ $search_word }} はヒットしませんでした。</p>
+            <p>{{ Str::limit($search_word, 10) }} はヒットしませんでした。</p>
         </section>
     @else 
         <section class="content">
             <div class="title has-text-centered m-5">
-                <p class="is-size-4 is-text-weight-bold">{{ $search_word }} に関するメモ一覧</p>
+                <p class="is-size-4 is-text-weight-bold">{{ Str::limit($search_word, 20) }} に関するメモ一覧</p>
             </div>
             <div class="columns">
                 <div class="column is-2">
                     <div class="category p-5">
                         @foreach($categories as $category)
-                            <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span><br>
+                            <form action="{{ route('memos.search.category') }}" method="POST">
+                                @csrf 
+                                <input type="hidden" name="category" value="{{ $category }}">
+                                @if ($category == $search_word)
+                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span></button>
+                                @else 
+                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span></button>
+                                @endif
+                            </form>
                         @endforeach
                     </div>
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3">
-                            <div class="category">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px;">
+                            <div class="category is-flex">
                                 @foreach($memo->categories->pluck('name') as $category)
-                                    <span class="tag"><i class="fas fa-tape"></i>{{ $category }}</span>
+                                    <form action="{{ route('memos.search.category') }}" method="POST">
+                                        @csrf 
+                                        <input type="hidden" name="category" value="{{ $category }}">
+                                        @if ($category == $search_word)
+                                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
+                                        @else 
+                                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
+                                        @endif
+                                    </form>
                                 @endforeach
                             </div><br>
                             <div class="title">
@@ -78,7 +94,7 @@
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                     <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ $memo->title }}" type="submit"
+                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 20) }}" type="submit"
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>
                             </div>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -76,15 +76,15 @@
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
                         <div class="memo column is-5 box m-3" style="min-width: 300px;">
-                            <div class="category is-flex">
+                            <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
-                                    <form action="{{ route('memos.search.category') }}" method="POST">
+                                    <form action="{{ route('memos.search.category') }}" method="POST" style="display: inline">
                                         @csrf 
                                         <input type="hidden" name="category" value="{{ $category }}">
                                         @if ($category == $search_word)
-                                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
+                                            <button style="background: none; border: 0px;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
                                         @else 
-                                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
+                                            <button style="background: none; border: 0px;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
                                         @endif
                                     </form>
                                 @endforeach

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search.title') }}" method="POST">
+                        <form action="{{ route('memos.search.title') }}" method="GET">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">
@@ -61,7 +61,7 @@
                 <div class="column is-2">
                     <div class="category p-5">
                         @foreach($categories as $category)
-                            <form action="{{ route('memos.search.category') }}" method="POST">
+                            <form action="{{ route('memos.search.category') }}" method="GET">
                                 @csrf 
                                 <input type="hidden" name="category" value="{{ $category }}">
                                 @if ($category == $search_word)
@@ -109,13 +109,22 @@
             </div>
             <div class="columns">
                 <div class="column">
-                    <div class="paging has-text-centered mt-5">
-                        <a href="">1</a>
-                        <a href="">2</a>
-                        <a href="">3</a>
-                        <a href="">4</a>
-                        <a class="ml-5" href="">次へ</a>
-                    </div>
+                    <nav class="pagination is-centered" role="navigation" aria-label="pagination">
+                        <ul class="pagination-list">
+                            {{-- @if($memos->currentPage() == 1)
+                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                                <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
+                            @elseif($memos->currentPage() == $memos->lastPage())
+                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                            @else  --}}
+                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
+                                <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
+                            {{-- @endif --}}
+                        </ul>
+                        {{ $memos->links() }}
+                    </nav>
                 </div>
             </div>
         </section>
@@ -147,7 +156,7 @@
     <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
     <script>
         $(function () {
-            let memoData = @json($memo_data ?? []);
+            let memoData = @json($memos->pluck('memo_data') ?? []);
             let memoLength = memoData.length;
 
             for(let index=0;index<memoLength;index++) {

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -48,7 +48,7 @@
             </div>
         </nav>
     </section>
-    @if($memos->isEmpty())
+    @if($hit_memos->isEmpty())
         <section class="content">
             <p>{{ Str::limit($search_word, 10) }} はヒットしませんでした。</p>
         </section>
@@ -74,19 +74,15 @@
                     </div>
                 </div>
                 <div class="memos columns is-multiline">
-                    @foreach($memos as $memo)
+                    @foreach($hit_memos as $memo)
                         <div class="memo column is-5 box m-3" style="min-width: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
-                                    <form action="{{ route('memos.search.category') }}" method="POST" style="display: inline">
-                                        @csrf 
-                                        <input type="hidden" name="category" value="{{ $category }}">
-                                        @if ($category == $search_word)
-                                            <button style="background: none; border: 0px;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
-                                        @else 
-                                            <button style="background: none; border: 0px;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 10) }}</span><br></button>
-                                        @endif
-                                    </form>
+                                    @if ($category == $search_word)
+                                        <span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
+                                    @else 
+                                        <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
+                                    @endif
                                 @endforeach
                             </div><br>
                             <div class="title">
@@ -94,7 +90,7 @@
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                     <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 20) }}" type="submit"
+                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 100) }}" type="submit"
                                     style="background: none; border: 0px; white-space: normal;">
                                 </form>
                             </div>
@@ -107,7 +103,7 @@
                     @endforeach
                 </div>
             </div>
-            <div class="columns">
+            {{-- <div class="columns">
                 <div class="column">
                     <nav class="pagination is-centered" role="navigation" aria-label="pagination">
                         <ul class="pagination-list">
@@ -118,15 +114,14 @@
                                 <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
                                 <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
                             @else  --}}
-                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
+                                {{-- <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
                                 <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
                                 <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
                             {{-- @endif --}}
-                        </ul>
-                        {{ $memos->links() }}
+                        {{-- </ul>
                     </nav>
-                </div>
-            </div>
+                </div> 
+            </div> --}}
         </section>
     @endif
     <section class="footer">
@@ -156,7 +151,7 @@
     <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
     <script>
         $(function () {
-            let memoData = @json($memos->pluck('memo_data') ?? []);
+            let memoData = @json($hit_memos->pluck('memo_data') ?? []);
             let memoLength = memoData.length;
 
             for(let index=0;index<memoLength;index++) {

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -63,7 +63,7 @@
                         @foreach($categories as $category)
                             <form action="{{ route('memos.search.category') }}" method="GET">
                                 @csrf 
-                                <input type="hidden" name="category" value="{{ $category }}">
+                                <input type="hidden" name="search_word" value="{{ $category }}">
                                 @if ($category == $search_word)
                                     <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
                                 @else 

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search.title') }}" method="GET">
+                        <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
                             <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
                             <span class="icon is-small is-left">
@@ -48,7 +48,7 @@
             </div>
         </nav>
     </section>
-    @if($hit_memos->isEmpty())
+    @if($memos->isEmpty())
         <section class="content">
             <p>{{ Str::limit($search_word, 10) }} はヒットしませんでした。</p>
         </section>
@@ -74,7 +74,7 @@
                     </div>
                 </div>
                 <div class="memos columns is-multiline">
-                    @foreach($hit_memos as $memo)
+                    @foreach($memos as $memo)
                         <div class="memo column is-5 box m-3" style="min-width: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
@@ -103,25 +103,30 @@
                     @endforeach
                 </div>
             </div>
-            {{-- <div class="columns">
+            <div class="columns">
                 <div class="column">
                     <nav class="pagination is-centered" role="navigation" aria-label="pagination">
                         <ul class="pagination-list">
-                            {{-- @if($memos->currentPage() == 1)
-                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
-                                <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
-                            @elseif($memos->currentPage() == $memos->lastPage())
-                                <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
-                            @else  --}}
-                                {{-- <li><a class="pagination-previous" href="{{ $memos->previousPageUrl() }}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
-                                <li><a class="pagination-next" href="{{ $memos->nextPageUrl() }}">次のページ</a></li>
-                            {{-- @endif --}}
-                        {{-- </ul>
+                            {{-- 1ページしか存在しない場合 --}}
+                            @if ($current_page == 1)
+                                @if ($current_page == $total_pages)
+                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                                @else 
+                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                                    <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}">次のページ</a></li>
+                                @endif
+                            @elseif($current_page == $total_pages)
+                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                            @else 
+                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                                <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}">次のページ</a></li>
+                            @endif
+                        </ul>
                     </nav>
                 </div> 
-            </div> --}}
+            </div>
         </section>
     @endif
     <section class="footer">
@@ -151,7 +156,7 @@
     <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
     <script>
         $(function () {
-            let memoData = @json($hit_memos->pluck('memo_data') ?? []);
+            let memoData = @json($memos->pluck('memo_data') ?? []);
             let memoLength = memoData.length;
 
             for(let index=0;index<memoLength;index++) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::prefix('memos')->group(function () {
     Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');
     Route::post('show', [MemoController::class, 'show'])->name('memos.show');
-    Route::get('search_title', [MemoController::class, 'searchTitle'])->name('memos.search.title');
+    Route::get('search', [MemoController::class, 'search'])->name('memos.search');
     Route::get('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,8 +22,8 @@ Route::prefix('memos')->group(function () {
     Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');
     Route::post('show', [MemoController::class, 'show'])->name('memos.show');
-    Route::post('search_title', [MemoController::class, 'searchTitle'])->name('memos.search.title');
-    Route::post('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
+    Route::get('search_title', [MemoController::class, 'searchTitle'])->name('memos.search.title');
+    Route::get('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');
     })->name('memos.get.input');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,8 @@ Route::prefix('memos')->group(function () {
     Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');
     Route::post('show', [MemoController::class, 'show'])->name('memos.show');
-    Route::post('search', [MemoController::class, 'search'])->name('memos.search');
+    Route::post('search_title', [MemoController::class, 'searchTitle'])->name('memos.search.title');
+    Route::post('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');
     })->name('memos.get.input');


### PR DESCRIPTION
キーワードでのメモ検索機能を実装しました。
検索した際にすべてのメモデータを返すのではなく、
ページネーションを用いて6件ずつ表示するようにしました。
カテゴリのタグを押したときには、カテゴリで検索を掛けるように
実装しました。
検索を掛けた際に、キーワードとカテゴリが一致していた場合は
そのカテゴリのタグの色だけis-primaryになるようにしました。
下のキャプチャーが検索をかける前と後です。
検索機能周辺が大変汚いコードになっているので、後でリファクタリングを
行います。
レビューをよろしくお願いいたします。
![検索前](https://user-images.githubusercontent.com/42739038/141958477-85d7d9be-58be-4047-ad39-5013dcd12175.png)
![検索後](https://user-images.githubusercontent.com/42739038/141958487-2a453209-3f34-4aa6-b0bd-b311ac911e0e.png)


