### PR TITLE
メモデータ検索機能の不具合を修正。

### DIFF
--- a/app/Http/Requests/StoreMemoRequest.php
+++ b/app/Http/Requests/StoreMemoRequest.php
@@ -27,8 +27,6 @@ class StoreMemoRequest extends FormRequest
         return [
             'categories' => 'required|max:154',
             'categories_count' => 'required|regex:/[1-5]/',
-            'title' => 'required|max:100',
-            'memo_count' => 'required|max:3000',
         ];
     }
 
@@ -40,7 +38,6 @@ class StoreMemoRequest extends FormRequest
     public function messages()
     {
         return [
-            'title.max:100' => 'カテゴリは100文字以内に収めてください。',
             'categories_count.regex' => 'カテゴリの最大数は5つです。',
             'categories_count.required' => 'カテゴリは必須です。'
         ];
@@ -54,7 +51,6 @@ class StoreMemoRequest extends FormRequest
     public function attributes()
     {
         return [
-            'title' => 'メモのタイトル',
             'memo_count' => 'メモの文字数',
             'categories' => 'カテゴリ',
         ];

--- a/app/Models/Memo.php
+++ b/app/Models/Memo.php
@@ -18,7 +18,8 @@ class Memo extends Model
     protected $fillable = [
         'user_id',
         'title',
-        'memo_data'
+        'memo_data',
+        'memo_text'
     ];
 
     /**
@@ -29,15 +30,18 @@ class Memo extends Model
      * メモデータのタイトル。
      * @param string $memo_data
      * editor.jsで作成されたメモデータ。
+     * @param string $memo_text
+     * editor.jsで作成されたメモデータから抽出したテキスト部分。
+     * 検索機能で使用する。
      * @return int $memo->id 
      * DBに格納されたmemoレコードのid。
      */
-    public static function store(int $user_id, string $title, string $memo_data)
+    public static function store(int $user_id, string $memo_data, string $memo_text)
     {
         $memo = Memo::create([
             'user_id' => $user_id,
-            'title' => $title,
-            'memo_data' => $memo_data
+            'memo_data' => $memo_data,
+            'memo_text' => $memo_text
         ]);
 
         return $memo->id;

--- a/database/migrations/2021_10_07_062428_create_memos_table.php
+++ b/database/migrations/2021_10_07_062428_create_memos_table.php
@@ -16,8 +16,8 @@ class CreateMemosTable extends Migration
         Schema::create('memos', function (Blueprint $table) {
             $table->id()->comment('自動増分値');
             $table->integer('user_id')->comment('usersテーブルのid');
-            $table->string('title')->comment('メモのタイトル');
             $table->json('memo_data')->comment('editor.jsで作成したjsonメモデータ');
+            $table->string('memo_text')->comment('メモデータのテキスト');
             $table->timestamps();
         });
     }

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -56,9 +56,6 @@
                 <div class="created_at">
                     <span id="created_at"></span>
                 </div>
-                <div class="title mt-3">
-                    <h4 class="is-size-3" id="title"></h4>
-                </div>
                 <div class="category">
                     <i class="fas fa-tape"></i><span id="categories"></span>
                 </div>
@@ -140,14 +137,13 @@
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
                 crossorigin="anonymous">
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@2.19.3/dist/editor.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/code@latest"></script>
     <script>
         $(function () {
-            let title = @json($title);
             let categories = @json($categories);
             let memoData = @json($memo_data);
             memoData = JSON.parse(memoData);
@@ -155,7 +151,6 @@
             created_at = new Date(created_at);
             created_at = getStringFromDate(created_at);
             $('#created_at').text(created_at);
-            $('#title').text(title);
             $('#categories').text(categories);
 
             $(".settings").click(function() {
@@ -178,7 +173,16 @@
                 holder: 'editorjs',
                 readOnly: true,
                 minHeight: 50,
-                data: memoData
+                data: memoData,
+                tools: {
+                    header: {
+                        class: Header, 
+                        inlineToolbar: ['link'] 
+                    },        
+                    list: List,        
+                    quote: Quote,
+                    code: CodeTool
+                },
             });
         });
 

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -141,6 +141,10 @@
                 crossorigin="anonymous">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
     <script>
         $(function () {
             let title = @json($title);

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -85,17 +85,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="field">
-                            <label for="comment">タイトル<br><span class="has-text-danger">*必須 最大100文字まで</span></label><br>
-                            <span class="has-text-primary" id="count_title">残り100文字入力可能</span>
-                            <div class="control has-text-centered">
-                                <div class="field">
-                                    <div class="control">
-                                        <input type="text" name="title" id="title" class="input is-success" placeholder="タイトル" value="{{ $memo->title }}">
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="memo">
                             <label for="editorjs">メモ<br><span class="has-text-danger">*必須</span></label>
                             <div id="editorjsCnt"></div>
@@ -132,12 +121,11 @@
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
                 crossorigin="anonymous">
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@2.19.3/dist/editor.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/code@latest"></script>
     <script>
         $(function() {
             let memoData = @json($memo_data);
@@ -154,8 +142,8 @@
                         inlineToolbar: ['link'] 
                     },        
                     list: List,        
-                    checklist: Checklist,
                     quote: Quote,
+                    code: CodeTool,
                 },
                 data: memoData,
             });
@@ -172,9 +160,8 @@
 
                 editor.save().then((outputData) => {
                     $('#memo_data').val(JSON.stringify(outputData));
-                    console.log('Article data: ', outputData);
                 }).catch((error) => {
-                    console.log('Saving failed: ', error);
+
                 });
             });
 
@@ -187,13 +174,6 @@
                 $("#disp_category").html(tags);
                 let arrayLength = textToArray.length;
                 $('#categories_count').val(arrayLength);
-            });
-
-            $("#title").keyup(function() {
-                const id = "#count_title";
-                let limit = 100;
-                let countTitle = $(this).val().length;
-                countText(id, limit, countTitle);
             });
         });
 

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -133,6 +133,11 @@
                 crossorigin="anonymous">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
     <script>
         $(function() {
             let memoData = @json($memo_data);
@@ -143,6 +148,15 @@
             const editor = new EditorJS({
                 minHeight: 50,
                 holder: 'editorjs',
+                tools: {
+                    header: {
+                        class: Header, 
+                        inlineToolbar: ['link'] 
+                    },        
+                    list: List,        
+                    checklist: Checklist,
+                    quote: Quote,
+                },
                 data: memoData,
             });
 

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -77,17 +77,16 @@
                                     <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                 @endforeach
                             </div><br>
-                            <div class="title">
+                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
+                            </div><br>
+                            <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                     <input type="hidden" name="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 100) }}" type="submit"
-                                    style="background: none; border: 0px; white-space: normal;">
+                                    <input type="submit" value="メモ詳細へ" class="button is-link">
                                 </form>
                             </div>
-                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
-                            </div><br>
                             <div class="post-time">
                                 <p>{{ $memo->created_at->diffForHumans() }}</p>
                             </div>

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -131,11 +131,24 @@
                 crossorigin="anonymous">
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
     <script>
         $(function() {
             const editor = new EditorJS({
                 minHeight: 50,
                 holder: 'editorjs',
+                tools: {
+                    header: {
+                        class: Header, 
+                        inlineToolbar: ['link'] 
+                    },        
+                    list: List,        
+                    checklist: Checklist,
+                    quote: Quote,
+                },
                 onChange: () => {
                     let myCode = $('#editorjs').html();
                     let cleanCode = myCode.replace(/<(?:.|\n)*?>/gm, '').replace(/(\r\n|\n|\r)/gm,"").replace('&nbsp;','');

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -78,17 +78,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="field">
-                            <label for="comment">タイトル<br><span class="has-text-danger">*必須 最大100文字まで</span></label><br>
-                            <span class="has-text-primary" id="count_title">残り100文字入力可能</span>
-                            <div class="control has-text-centered">
-                                <div class="field">
-                                    <div class="control">
-                                        <input type="text" name="title" id="title" class="input is-success" placeholder="タイトルを入力" maxlength="100" required>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="editor_field">
                             <label for="editor">メモ<br><span class="has-text-danger">*必須 3000文字以内</span></label>
                             <div id="editorjsCnt"></div>
@@ -130,11 +119,11 @@
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
                 crossorigin="anonymous">
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@2.19.3/dist/editor.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/list@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/checklist@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/quote@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/code@latest"></script>
     <script>
         $(function() {
             const editor = new EditorJS({
@@ -146,8 +135,8 @@
                         inlineToolbar: ['link'] 
                     },        
                     list: List,        
-                    checklist: Checklist,
                     quote: Quote,
+                    code: CodeTool
                 },
                 onChange: () => {
                     let myCode = $('#editorjs').html();
@@ -157,13 +146,11 @@
                     if(numChars < 0) {
                         numChars = 0;
                     }
+                    console.log(cleanCode);
                     $('#editorjsCnt').text(numChars + "文字入力されています。");
                     $('#memo_count').val(cleanCode);
                 }
             });
-
-            
-
 
             $("#post_memo").click(function() {
                 editor.save().then((outputData) => {
@@ -183,13 +170,6 @@
                 $("#disp_category").html(tags);
                 let arrayLength = textToArray.length;
                 $('#categories_count').val(arrayLength);
-            });
-
-            $("#title").keyup(function() {
-                const id = "#count_title";
-                let limit = 100;
-                let countTitle = $(this).val().length;
-                countText(id, limit, countTitle);
             });
         });
 

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -64,7 +64,7 @@
                             <form action="{{ route('memos.search.category') }}" method="GET">
                                 @csrf 
                                 <input type="hidden" name="search_word" value="{{ $category }}">
-                                @if ($category == $search_word)
+                                @if ($category === $search_word)
                                     <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
                                 @else 
                                     <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
@@ -75,27 +75,26 @@
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3" style="min-width: 300px;">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
-                                    @if ($category == $search_word)
+                                    @if($category === $search_word)
                                         <span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                     @else 
                                         <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                     @endif
                                 @endforeach
                             </div><br>
-                            <div class="title">
+                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
+                            </div><br>
+                            <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">
-                                    <input type="hidden" name="memo_data" id="memo_data" value="{{ $memo->memo_data }}">
-                                    <input class="is-size-5 has-text-weight-bold has-text-link" value="{{ Str::limit($memo->title, 100) }}" type="submit"
-                                    style="background: none; border: 0px; white-space: normal;">
+                                    <input type="hidden" name="memo_data" value="{{ $memo->memo_data }}">
+                                    <input type="submit" value="メモ詳細へ" class="button is-link">
                                 </form>
                             </div>
-                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
-                            </div><br>
                             <div class="post-time">
                                 <p>{{ $memo->created_at->diffForHumans() }}</p>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,10 +26,10 @@ Route::prefix('memos')->group(function () {
     Route::get('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');
-    })->name('memos.get.input');
+    })->middleware('auth')->name('memos.get.input');
     Route::get('get/deleted', function () {
         return view('EngineerStack.deleted_memo');
-    })->name('memos.deleted');
+    })->middleware('auth')->name('memos.deleted');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
メモデータ検索機能の不具合を修正しました。
不具合の内容は、editor.jsで作成したメモデータの文字列検索ができないことでした。
解決策として行ったことは、editor.jsのメモデータをDBへ挿入する際に、
メモデータから検索用の文字列を抽出して、新たにmemosテーブルへmemo_data
カラムを作成し、そこへ検索用の文字列を格納することでメモデータの検索が可能になりました。
検索のビジネスロジックはMemoService.phpへ書きました。
カテゴリ検索とキーワード検索のロジックを分けた理由は、1つにまとめてしまうと検索の精度が
落ちてしまうことを考え、あえて分けました。
