### PR TITLE
カテゴリをパネル形式で表示するように実装。

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -11,7 +11,6 @@ use App\Services\CategoryService;
 class CategoryController extends Controller
 {
     private $category;
-
     /**
      * コンストラクタでmiddleware('auth');
      * を設定しているので、ログイン前では
@@ -24,6 +23,13 @@ class CategoryController extends Controller
     {
         $this->middleware('auth');
         $this->category = $categoryService;
+    }
+
+    public function index(Request $request)
+    {
+        $user_id = Auth::id();
+        $categories = Category::where('user_id', $user_id)->get();
+        return view('EngineerStack.all_categories', compact('categories'));
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -72,7 +72,6 @@ class MemoController extends Controller
                                             'categories', 'memo_id'));
         } catch (Exception $exception) {
             DB::rollback();
-            dd($exception);
             return redirect()->route('dashboard');
         }
     }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -38,9 +38,10 @@ class MemoController extends Controller
     public function index()
     {
         $user_id = Auth::id();
-        $memos = Memo::where('user_id', $user_id)->paginate(6);
+        $memos = Memo::where('user_id', $user_id)->orderBy('updated_at', 'desc')->paginate(6);
         $posted_memos = Memo::where('user_id', $user_id)->get();
         $categories = $this->memo->getCategories($posted_memos);
+        $categories = $categories->slice(0, 15);
         return view('EngineerStack.home', compact('memos', 'categories'));
     }
 
@@ -207,5 +208,13 @@ class MemoController extends Controller
         }
         Memo::destroy($memo_id);
         return redirect()->route('memos.deleted');
+    }
+
+    public function allCategories()
+    {
+        $user_id = Auth::id();
+        $posted_memos = Memo::where('user_id', $user_id)->get();
+        $categories = $this->memo->getCategories($posted_memos);
+        return view('EngineerStack.all_categories', compact('categories'));
     }
 }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -97,9 +97,8 @@ class MemoController extends Controller
 
         $memo = Memo::find($memo_id);
         $categories = Memo::find($memo_id)->categories->pluck('name');
-        $memo_data = $memo['memo_data'];
         return view('EngineerStack.edit_memo'
-                , compact('memo', 'memo_data', 'categories'));
+                , compact('memo', 'categories'));
     }
 
     /**
@@ -126,8 +125,9 @@ class MemoController extends Controller
         DB::beginTransaction();
 
         try {
+            $memo_text = $this->memo->getMemoText($memo_data);
             Memo::where('id', $memo_id)
-                    ->update(['memo_data' => $memo_data]);
+                    ->update(['memo_data' => $memo_data, 'memo_text' => $memo_text]);
             $this->memo->categoriesSync($memo_id, $categories);
             $memo_data = Memo::find($memo_id)->memo_data;
             DB::commit();
@@ -172,9 +172,9 @@ class MemoController extends Controller
      * @return Illuminate\View\View
      * メモ検索結果を返します。
      */
-    public function search(Request $request)
+    public function searchKeyword(Request $request)
     {
-        return $this->memo->search($request);
+        return $this->memo->searchKeyword($request);
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -71,6 +71,7 @@ class MemoController extends Controller
                                             'categories', 'memo_id'));
         } catch (Exception $exception) {
             DB::rollback();
+            dd($exception);
             return redirect()->route('dashboard');
         }
     }

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -208,6 +208,7 @@
                 }
             }
 
+            $memo_text = htmlspecialchars($memo_text, ENT_QUOTES, 'UTF-8');
             return $memo_text;
         }
 

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -99,6 +99,7 @@
         public function getCategories(object $memos)
         {
             $get_categories = app()->make('App\Http\Controllers\CategoryController');
+            $memos = $memos->sortByDesc('id');
             $categories = $get_categories->getCategories($memos);
             return $categories;
         }
@@ -107,6 +108,7 @@
         {
             $memos = collect();
             $category_id = Category::where('name', $category)->pluck('id');
+            if($category_id->isEmpty()) { return; }
             $memo_ids = CategoryMemo::where('category_id', $category_id)->pluck('memo_id');
             $memo_count = count($memo_ids);
             for($index = 0; $index < $memo_count; $index++) {
@@ -162,7 +164,14 @@
             if(empty($current_page)) {
                 $current_page = 1;
             }
-            $memos = $hit_memos->forPage($current_page, 6);
+
+            if($hit_memos === null) {
+                $memos = collect();
+                $hit_memos = collect();
+            } else {
+                $memos = $hit_memos->forPage($current_page, 6);
+            }
+            
             $total_pages = (int)ceil(count($hit_memos)/6);
             return view('EngineerStack.search_result', 
                     compact('search_word', 'memos','categories', 'current_page', 'total_pages'));

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -125,7 +125,7 @@
          * @return Illuminate\View\View
          * メモ検索結果を返します。
          */
-        public function search(Request $request)
+        public function searchKeyword(Request $request)
         {
             $user_id = Auth::id();
             $search_word = $request->input('search_word');
@@ -139,8 +139,8 @@
             if(empty($current_page)) {
                 $current_page = 1;
             }
-            $memos = $memos->forPage($current_page, 6);
             $total_pages = (int)ceil(count($memos)/6);
+            $memos = $memos->forPage($current_page, 6);
             return view('EngineerStack.search_result', 
                     compact('search_word', 'memos', 'categories', 'current_page', 'total_pages'));
         }
@@ -217,7 +217,6 @@
                 }
             }
 
-            $memo_text = htmlspecialchars($memo_text, ENT_QUOTES, 'UTF-8');
             return $memo_text;
         }
 

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+    <title>カテゴリ一覧 EngineerStack</title>
+</head>
+<body>
+    <section class="header">
+        <nav class="navbar" role="navigation" aria-label="main navigation">
+            <div class="navbar-brand">
+                <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
+                    EngineerStack
+                </a>
+                <div class="field mt-4 ml-5">
+                    <div class="control has-icons-left has-icons-right">
+                        <form action="{{ route('memos.search') }}" method="GET">
+                            @csrf 
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-search"></i>
+                            </span>
+                        </form>
+                    </div>
+                </div>
+                <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                </a>
+            </div>
+            <div id="navbarBasicExample" class="navbar-menu">
+                <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="buttons">
+                            <a class="button is-primary" href="{{ route('memos.get.input') }}">
+                                <strong>記録</strong>
+                            </a>
+                            <form action="{{ route('logout') }}" method="POST">
+                                @csrf
+                                <input type="submit" class="button is-light" value="ログアウト">
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </section>
+    @if($categories->isEmpty())
+        <section class="content">
+            <p>まだカテゴリは投稿されていません。</p>
+        </section>
+    @else 
+        <section class="content">
+            <div class="title has-text-centered m-5">
+                <p class="is-size-4 is-text-weight-bold">カテゴリ一覧</p>
+            </div>
+            <div class="columns is-multiline categories p-5">
+                @foreach($categories as $category)
+                    <div class="column category">
+                        <form action="{{ route('memos.search.category') }}">
+                            @csrf
+                            <input type="hidden" name="search_word" value="{{ $category }}">
+                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-link is-size-3"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
+                        </form>
+                    </div>
+                @endforeach
+            </div>
+        </section>
+    @endif
+    <section class="footer">
+        <div class="columns">
+            <div class="column">
+                <a class="navbar-item is-size-5 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
+                    EngineerStack
+                </a>
+                <span class="m-3">&copy;otake619 2021</span>
+            </div>
+            <div class="column m-3">
+                <p class="mb-3">EngineerStack</p>
+                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="">リリース</a><br>
+                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="">お問い合わせ</a>
+            </div>
+        </div>
+    </section>
+    <script src="{{ asset('js/app.js') }}"></script>
+    <script src="{{ asset('js/navbar.js') }}"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"
+                integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
+                crossorigin="anonymous">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
+</body>
+</html>

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -128,7 +128,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@editorjs/code@latest"></script>
     <script>
         $(function() {
-            let memoData = @json($memo_data);
+            let memoData = @json($memo['memo_data']);
             memoData = JSON.parse(memoData);
             let categories = @json($categories);
             $('#category').val(categories);

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -67,7 +67,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリで検索">
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索">
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
@@ -100,7 +100,7 @@
                                     <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                 @endforeach
                             </div><br>
-                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
+                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word">
                             </div><br>
                             <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
@@ -121,7 +121,6 @@
                 <div class="column">
                     <nav class="pagination is-centered" role="navigation" aria-label="pagination">
                         <ul class="pagination-list">
-                            {{-- ページネーションが正しく動作していない。 --}}
                             @if($memos->currentPage() == 1)
                                 @if($memos->currentPage() == $memos->lastPage())
                                     <li><a class="pagination-link is-current" aria-current="page">{{ $memos->currentPage() }}</a></li>
@@ -164,54 +163,24 @@
     <script src="{{ asset('js/navbar.js') }}"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.js"
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
-                crossorigin="anonymous">
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
+                crossorigin="anonymous"></script>
     <script>
         $(function () {
-            let memoData = @json($memos->pluck('memo_data') ?? []);
-            let memoLength = memoData.length;
-
-            for(let index=0;index<memoLength;index++) {
-                let data = memoData[index];
-                data = JSON.parse(data);
-                let post_time = data.time;
-                post_time = new Date(post_time);
-                data = jsonConvertHtml(data);
-                let data_id = `#data_${index}`;
-                $(data_id).html(data);
-                post_time = getStringFromDate(post_time);
-                let time_id = `#time_${index}`;
-                $(time_id).text(post_time);
-            } 
+            let memos = @json($memos);
+            const memosLength = memos['data'].length;
+            for(let index = 0; index < memosLength; index++) {
+                const id = `#memo_${memos['data'][index]['id']}`;
+                const text = sanitizeDecode(memos['data'][index]['memo_text']);
+                $(id).text(text);
+            }
         });
 
-        function getStringFromDate(date) {
-        
-            let year_str = date.getFullYear();
-            let month_str = 1 + date.getMonth();
-            let day_str = date.getDate();
-            let hour_str = date.getHours();
-            let minute_str = date.getMinutes();
-            let second_str = date.getSeconds();
-            
-            
-            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に投稿';
-            format_str = format_str.replace(/YYYY/g, year_str);
-            format_str = format_str.replace(/MM/g, month_str);
-            format_str = format_str.replace(/DD/g, day_str);
-            format_str = format_str.replace(/hh/g, hour_str);
-            format_str = format_str.replace(/mm/g, minute_str);
-            format_str = format_str.replace(/ss/g, second_str);
-            
-            return format_str;
-        };
-
-        function jsonConvertHtml(jsonData) {
-            const edjsParser = edjsHTML();
-            let html = edjsParser.parse(jsonData);
-            return html;
+        function sanitizeDecode(text) {
+            return text.replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, '\'')
+            .replace(/&amp;/g, '&');
         }
     </script>
 </body>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -59,7 +59,7 @@
             </div>
             <div class="columns">
                 <div class="column is-4">
-                    <div class="category p-5">
+                    <div class="categories p-5">
                         <nav class="panel">
                             <p class="panel-heading">
                                 カテゴリ
@@ -77,19 +77,18 @@
                                 <span>最新15カテゴリ</span>
                             </p>
                             <div class="category">
-                                @foreach($categories->chunk(50) as $chunk)
-                                    @foreach ($chunk as $category)
-                                        <div class="panel-block" id="category_{{ $loop->index }}">
-                                            <form action="{{ route('memos.search.category') }}">
-                                                @csrf
-                                                <input type="hidden" name="search_word" value="{{ $category }}">
-                                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
-                                            </form>
-                                        </div>
-                                    @endforeach
+                                @foreach($categories as $category)
+                                    <form action="{{ route('memos.search.category') }}">
+                                        @csrf
+                                        <input type="hidden" name="search_word" value="{{ $category }}">
+                                        <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
+                                    </form>
                                 @endforeach
                             </div>
-                            <a href="" class="panel-tabs"><span>カテゴリ一覧へ</span></a>
+                            <form action="{{ route('memos.all_categories') }}">
+                                @csrf
+                                <button type="submit" class="button is-link">カテゴリ一覧へ</button>
+                            </form>
                         </nav>
                     </div>
                 </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -71,7 +71,7 @@
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3" style="min-width: 300px">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>
@@ -58,15 +58,39 @@
                 <p class="is-size-4 is-text-weight-bold">メモ一覧</p>
             </div>
             <div class="columns">
-                <div class="column is-2">
+                <div class="column is-4">
                     <div class="category p-5">
-                        @foreach($categories as $category)
-                            <form action="{{ route('memos.search.category') }}">
-                                @csrf 
-                                <input type="hidden" name="search_word" value="{{ $category }}">
-                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
-                            </form>
-                        @endforeach
+                        <nav class="panel">
+                            <p class="panel-heading">
+                                カテゴリ
+                            </p>
+                            <div class="control has-icons-left has-icons-right m-1">
+                                <form action="{{ route('memos.search.category') }}" method="GET">
+                                    @csrf 
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリで検索">
+                                    <span class="icon is-small is-left">
+                                        <i class="fas fa-search"></i>
+                                    </span>
+                                </form>
+                            </div>
+                            <p class="panel-tabs">
+                                <span>最新15カテゴリ</span>
+                            </p>
+                            <div class="category">
+                                @foreach($categories->chunk(50) as $chunk)
+                                    @foreach ($chunk as $category)
+                                        <div class="panel-block" id="category_{{ $loop->index }}">
+                                            <form action="{{ route('memos.search.category') }}">
+                                                @csrf
+                                                <input type="hidden" name="search_word" value="{{ $category }}">
+                                                <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
+                                            </form>
+                                        </div>
+                                    @endforeach
+                                @endforeach
+                            </div>
+                            <a href="" class="panel-tabs"><span>カテゴリ一覧へ</span></a>
+                        </nav>
                     </div>
                 </div>
                 <div class="memos columns is-multiline">

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -55,7 +55,7 @@
     @else 
         <section class="content">
             <div class="title has-text-centered m-5">
-                <p class="is-size-4 is-text-weight-bold">{{ Str::limit($search_word, 20) }} に関するメモ一覧</p>
+                <p class="is-size-4 is-text-weight-bold">{{ Str::limit($search_word, 20) }} に関するメモ {{ $current_page }}ページ目</p>
             </div>
             <div class="columns">
                 <div class="column is-4">
@@ -67,7 +67,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリで検索">
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索">
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
@@ -104,7 +104,7 @@
                                     @endif
                                 @endforeach
                             </div><br>
-                            <div id="data_{{ $loop->index }}" style="overflow-wrap: break-word">
+                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word">
                             </div><br>
                             <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
@@ -125,7 +125,6 @@
                 <div class="column">
                     <nav class="pagination is-centered" role="navigation" aria-label="pagination">
                         <ul class="pagination-list">
-                            {{-- 1ページしか存在しない場合 --}}
                             @if ($current_page == 1)
                                 @if ($current_page == $total_pages)
                                     <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
@@ -168,54 +167,28 @@
     <script src="{{ asset('js/navbar.js') }}"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.js"
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
-                crossorigin="anonymous">
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
-    <script src="https://cdn.jsdelivr.net/npm/editorjs-html@3.4.0/build/edjsHTML.js"></script>
+                crossorigin="anonymous"></script>
     <script>
         $(function () {
-            let memoData = @json($memos->pluck('memo_data') ?? []);
-            let memoLength = memoData.length;
-
-            for(let index=0;index<memoLength;index++) {
-                let data = memoData[index];
-                data = JSON.parse(data);
-                let post_time = data.time;
-                post_time = new Date(post_time);
-                data = jsonConvertHtml(data);
-                let data_id = `#data_${index}`;
-                $(data_id).html(data);
-                post_time = getStringFromDate(post_time);
-                let time_id = `#time_${index}`;
-                $(time_id).text(post_time);
-            } 
+            const memos = @json($memos);
+            const currentPage = parseInt(@json($current_page));
+            const memosLength = Object.keys(memos).length;
+            const indexStart = (currentPage - 1) * 6;
+            for(let index = indexStart; index < indexStart + memosLength; index++) {
+                let id = `#memo_${memos[index]['id']}`;
+                let text = sanitizeDecode(memos[index]['memo_text']);
+                $(id).text(text);
+                console.log(text);
+                console.log(id);
+            }
         });
 
-        function getStringFromDate(date) {
-        
-            let year_str = date.getFullYear();
-            let month_str = 1 + date.getMonth();
-            let day_str = date.getDate();
-            let hour_str = date.getHours();
-            let minute_str = date.getMinutes();
-            let second_str = date.getSeconds();
-            
-            
-            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に投稿';
-            format_str = format_str.replace(/YYYY/g, year_str);
-            format_str = format_str.replace(/MM/g, month_str);
-            format_str = format_str.replace(/DD/g, day_str);
-            format_str = format_str.replace(/hh/g, hour_str);
-            format_str = format_str.replace(/mm/g, minute_str);
-            format_str = format_str.replace(/ss/g, second_str);
-            
-            return format_str;
-        };
-
-        function jsonConvertHtml(jsonData) {
-            const edjsParser = edjsHTML();
-            let html = edjsParser.parse(jsonData);
-            return html;
+        function sanitizeDecode(text) {
+            return text.replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, '\'')
+            .replace(/&amp;/g, '&');
         }
     </script>
 </body>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -58,19 +58,38 @@
                 <p class="is-size-4 is-text-weight-bold">{{ Str::limit($search_word, 20) }} に関するメモ一覧</p>
             </div>
             <div class="columns">
-                <div class="column is-2">
-                    <div class="category p-5">
-                        @foreach($categories as $category)
-                            <form action="{{ route('memos.search.category') }}" method="GET">
-                                @csrf 
-                                <input type="hidden" name="search_word" value="{{ $category }}">
-                                @if ($category === $search_word)
-                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-primary"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
-                                @else 
-                                    <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span></button>
-                                @endif
+                <div class="column is-4">
+                    <div class="categories p-5">
+                        <nav class="panel">
+                            <p class="panel-heading">
+                                カテゴリ
+                            </p>
+                            <div class="control has-icons-left has-icons-right m-1">
+                                <form action="{{ route('memos.search.category') }}" method="GET">
+                                    @csrf 
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリで検索">
+                                    <span class="icon is-small is-left">
+                                        <i class="fas fa-search"></i>
+                                    </span>
+                                </form>
+                            </div>
+                            <p class="panel-tabs">
+                                <span>最新15カテゴリ</span>
+                            </p>
+                            <div class="category">
+                                @foreach($categories as $category)
+                                    <form action="{{ route('memos.search.category') }}">
+                                        @csrf
+                                        <input type="hidden" name="search_word" value="{{ $category }}">
+                                        <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
+                                    </form>
+                                @endforeach
+                            </div>
+                            <form action="{{ route('memos.all_categories') }}">
+                                @csrf
+                                <button type="submit" class="button is-link">カテゴリ一覧へ</button>
                             </form>
-                        @endforeach
+                        </nav>
                     </div>
                 </div>
                 <div class="memos columns is-multiline">

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@ Route::get('/', function () {
 
 Route::get('/dashboard', [MemoController::class, 'index'])->middleware(['auth'])->name('dashboard');
 
-Route::prefix('user')->group(function () {
+Route::prefix('users')->group(function () {
 
 });
 
@@ -24,6 +24,7 @@ Route::prefix('memos')->group(function () {
     Route::post('show', [MemoController::class, 'show'])->name('memos.show');
     Route::get('search', [MemoController::class, 'search'])->name('memos.search');
     Route::get('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
+    Route::get('all_categories', [MemoController::class, 'allCategories'])->name('memos.all_categories');
     Route::get('get/store', function () {
         return view('EngineerStack.input_memo');
     })->middleware('auth')->name('memos.get.input');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::prefix('memos')->group(function () {
     Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');
     Route::post('show', [MemoController::class, 'show'])->name('memos.show');
-    Route::get('search', [MemoController::class, 'search'])->name('memos.search');
+    Route::get('search', [MemoController::class, 'searchKeyword'])->name('memos.search');
     Route::get('search_category', [MemoController::class, 'searchCategory'])->name('memos.search.category');
     Route::get('all_categories', [MemoController::class, 'allCategories'])->name('memos.all_categories');
     Route::get('get/store', function () {


### PR DESCRIPTION
カテゴリの数が増えてくるとレイアウトが崩れてしまうので、
カテゴリをパネル形式で表示するように実装しました。
editor.jsでページネーション時にメモ部分が表示されなくなる不具合を確認したので修正。
スクショは最新のホーム画面とカテゴリ一覧画面です。
![ホーム画面](https://user-images.githubusercontent.com/42739038/143010958-797ec12d-d21c-4b52-b261-56e941bbec2e.png)

![カテゴリ一覧画面](https://user-images.githubusercontent.com/42739038/143010969-1067b6a1-77e3-4b8e-839b-bed71d490e9f.png)

