### PR TITLE
投稿時間順で検索時に昇順、降順指定を出来るようにした。

### DIFF
--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -130,11 +130,22 @@
             $user_id = Auth::id();
             $search_word = $request->input('search_word');
             $current_page = $request->input('page');
+            $sort = $request->input('sort');
             $all_memos = Memo::where('user_id', $user_id)->get();
             $categories = $this->getCategories($all_memos);
-
-            $memos = Memo::where('user_id', $user_id)
+            if($sort == "ascend") {
+                $memos = Memo::where('user_id', $user_id)
+                        ->orderBy('updated_at', 'desc')
                         ->where('memo_text', 'LIKE', "%$search_word%")->get();
+            } elseif($sort == "descend") {
+                $memos = Memo::where('user_id', $user_id)
+                        ->orderBy('updated_at', 'asc')
+                        ->where('memo_text', 'LIKE', "%$search_word%")->get();
+            } else {
+                $memos = Memo::where('user_id', $user_id)
+                        ->orderBy('updated_at', 'desc')
+                        ->where('memo_text', 'LIKE', "%$search_word%")->get();
+            }
 
             if(empty($current_page)) {
                 $current_page = 1;
@@ -142,7 +153,8 @@
             $total_pages = (int)ceil(count($memos)/6);
             $memos = $memos->forPage($current_page, 6);
             return view('EngineerStack.search_result', 
-                    compact('search_word', 'memos', 'categories', 'current_page', 'total_pages'));
+                    compact('search_word', 'memos', 'categories',
+                     'current_page', 'total_pages', 'sort'));
         }
 
         /**
@@ -173,8 +185,11 @@
             }
             
             $total_pages = (int)ceil(count($hit_memos)/6);
+            //TODO カテゴリの検索結果の昇順・降順機能も実装
+            $sort = $request->input('sort');
             return view('EngineerStack.search_result', 
-                    compact('search_word', 'memos','categories', 'current_page', 'total_pages'));
+                    compact('search_word', 'memos','categories',
+                     'current_page', 'total_pages', 'sort'));
         }
 
         /**

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -33,6 +22,27 @@
             </div>
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
@@ -71,6 +81,12 @@
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
                                 </form>
                             </div>
                             <p class="panel-tabs">
@@ -87,7 +103,7 @@
                             </div>
                             <form action="{{ route('memos.all_categories') }}">
                                 @csrf
-                                <button type="submit" class="button is-link">カテゴリ一覧へ</button>
+                                <button type="submit" class="button is-link m-3">カテゴリ一覧へ</button>
                             </form>
                         </nav>
                     </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>
@@ -67,7 +67,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索">
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" required>
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -16,7 +16,7 @@
                 </a>
                 <div class="field mt-4 ml-5">
                     <div class="control has-icons-left has-icons-right">
-                        <input class="input is-success" type="text" placeholder="キーワードを入力">
+                        <input class="input is-success" type="text" placeholder="キーワードで検索" required>
                         <span class="icon is-small is-left">
                             <i class="fas fa-search"></i>
                         </span>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -33,6 +22,27 @@
             </div>
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
@@ -71,6 +81,12 @@
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
                                 </form>
                             </div>
                             <p class="panel-tabs">
@@ -87,7 +103,7 @@
                             </div>
                             <form action="{{ route('memos.all_categories') }}">
                                 @csrf
-                                <button type="submit" class="button is-link">カテゴリ一覧へ</button>
+                                <button type="submit" class="button is-link m-3">カテゴリ一覧へ</button>
                             </form>
                         </nav>
                     </div>
@@ -127,18 +143,18 @@
                         <ul class="pagination-list">
                             @if ($current_page == 1)
                                 @if ($current_page == $total_pages)
-                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
                                 @else 
-                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
-                                    <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}">次のページ</a></li>
+                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
+                                    <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
                                 @endif
                             @elseif($current_page == $total_pages)
-                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
+                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}&sort={{ $sort }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
                             @else 
-                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}">{{ $current_page }}</a></li>
-                                <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}">次のページ</a></li>
+                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}&sort={{ $sort }}">前のページ</a></li>
+                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
+                                <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
                             @endif
                         </ul>
                     </nav>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -18,7 +18,7 @@
                     <div class="control has-icons-left has-icons-right">
                         <form action="{{ route('memos.search') }}" method="GET">
                             @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードを入力">
+                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-search"></i>
                             </span>
@@ -67,7 +67,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索">
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" required>
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>


### PR DESCRIPTION
メモ検索時に、updated_atを使用して昇順、降順でソートできるようにしました。
検索フォームの横にある「最新のメモを検索」を選択すると昇順に「古い順に検索」
を選択すると降順にメモが表示されるように実装しました。
キャプチャーは最新のホーム画面です↓
![ホーム画面](https://user-images.githubusercontent.com/42739038/143389970-7a92f6fb-832e-4a74-8c27-caa6c2050bc2.png)


