### PR TITLE
メモ入力で文字数が多い場合にインサート処理できなかった不具合を改修。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -57,6 +57,7 @@ class MemoController extends Controller
      */
     public function store(StoreMemoRequest $request)
     {
+        $validated = $request->validated();
         $user_id = Auth::id();
         $categories = $request->input('categories');
         $memo_data = $request->input('memo_data');

--- a/app/Http/Requests/StoreMemoRequest.php
+++ b/app/Http/Requests/StoreMemoRequest.php
@@ -17,6 +17,10 @@ class StoreMemoRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation() 
+    {
+    }
+
     /**
      * リクエストに適用するルール
      *
@@ -25,8 +29,10 @@ class StoreMemoRequest extends FormRequest
     public function rules()
     {
         return [
-            'categories' => 'required|max:154',
-            'categories_count' => 'required|regex:/[1-5]/',
+            'category_flg' => ['boolean:true'],
+            'categories' => ['required', 'string'],
+            'categories_count' => ['required','integer' , 'max:5'],
+            'memo_count' => ['required','integer', 'max:1000']
         ];
     }
 
@@ -38,8 +44,11 @@ class StoreMemoRequest extends FormRequest
     public function messages()
     {
         return [
-            'categories_count.regex' => 'カテゴリの最大数は5つです。',
-            'categories_count.required' => 'カテゴリは必須です。'
+            'category_flg.boolean' => 'カテゴリは20文字以内です。',
+            'categories_count.max' => 'カテゴリの最大数は5つです。',
+            'categories_count.required' => 'カテゴリは必須です。',
+            'memo_count.max' => 'メモの最大入力文字を超えています。',
+            'memo_count.required' => 'メモの入力は必須です。'
         ];
     }
 
@@ -53,6 +62,8 @@ class StoreMemoRequest extends FormRequest
         return [
             'memo_count' => 'メモの文字数',
             'categories' => 'カテゴリ',
+            'categories_count' => 'カテゴリ数',
+            'category_flg' => '1つのカテゴリ'
         ];
     }
 }

--- a/database/migrations/2021_10_07_062428_create_memos_table.php
+++ b/database/migrations/2021_10_07_062428_create_memos_table.php
@@ -17,7 +17,7 @@ class CreateMemosTable extends Migration
             $table->id()->comment('自動増分値');
             $table->integer('user_id')->comment('usersテーブルのid');
             $table->json('memo_data')->comment('editor.jsで作成したjsonメモデータ');
-            $table->string('memo_text')->comment('メモデータのテキスト');
+            $table->text('memo_text')->comment('メモデータのテキスト');
             $table->timestamps();
         });
     }

--- a/database/migrations/2021_10_07_063628_create_categories_table.php
+++ b/database/migrations/2021_10_07_063628_create_categories_table.php
@@ -15,7 +15,7 @@ class CreateCategoriesTable extends Migration
     {
         Schema::create('categories', function (Blueprint $table) {
             $table->id()->comment('自動増分値');
-            $table->string('name')->comment('カテゴリー名');
+            $table->text('name')->comment('カテゴリー名');
             $table->timestamps();
         });
     }

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -33,6 +22,27 @@
             </div>
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
@@ -50,7 +60,9 @@
     </section>
     @if($categories->isEmpty())
         <section class="content">
-            <p>まだカテゴリは投稿されていません。</p>
+            <div class="notification is-warning">
+                <p>まだカテゴリは投稿されていません。</p>
+            </div>
         </section>
     @else 
         <section class="content">

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -33,6 +22,27 @@
             </div>
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
@@ -49,7 +59,7 @@
         </nav>
     </section>
     <section class="content">
-        <h4 class="has-text-primary">メモの削除が完了しました。</h4>
+        <h4 class="notification is-primary">メモの削除が完了しました。</h4>
     </section>
     <section class="footer">
         <div class="columns">

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -34,9 +23,30 @@
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
                     <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
-                                <i class="fas fa-pen"></i><strong>記録</strong>
+                                <strong>記録</strong>
                             </a>
                             <form action="{{ route('logout') }}" method="POST">
                                 @csrf

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -14,17 +14,6 @@
                 <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
                     EngineerStack
                 </a>
-                <div class="field mt-4 ml-5">
-                    <div class="control has-icons-left has-icons-right">
-                        <form action="{{ route('memos.search') }}" method="GET">
-                            @csrf 
-                            <input class="input is-success" type="text" name="search_word" placeholder="キーワードで検索" required>
-                            <span class="icon is-small is-left">
-                                <i class="fas fa-search"></i>
-                            </span>
-                        </form>
-                    </div>
-                </div>
                 <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -33,6 +22,27 @@
             </div>
             <div id="navbarBasicExample" class="navbar-menu">
                 <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="field ml-5">
+                            <div class="control has-icons-left has-icons-right">
+                                <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                    @csrf 
+                                    <div class="input-keyword">
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
+                                        <span class="icon is-small is-left">
+                                            <i class="fas fa-search"></i>
+                                        </span>
+                                    </div>
+                                    <div class="select">
+                                        <select name="sort">
+                                            <option value="ascend">最新のメモを検索</option>
+                                            <option value="descend">古い順に検索</option>
+                                        </select>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                     <div class="navbar-item">
                         <div class="buttons">
                             <a class="button is-primary" href="{{ route('memos.get.input') }}">
@@ -57,7 +67,7 @@
                         <h4 class="is-size-4">メモを編集する</h4>
                         <div class="errors">
                             @if ($errors->any())
-                                <div class="has-text-danger">
+                                <div class="notification is-danger">
                                     <ul>
                                         @foreach ($errors->all() as $error)
                                             <li>{{ $error }}</li>
@@ -80,7 +90,7 @@
                             <div class="control has-text-centered">
                                 <div class="field">
                                     <div class="control">
-                                        <input name="categories" id="category" type="text" class="input is-success" placeholder="カテゴリ">
+                                        <input name="categories" id="category" type="text" class="input is-success" placeholder="カテゴリ" maxlength="110" required>
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -28,7 +28,7 @@
                                 <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
                                     @csrf 
                                     <div class="input-keyword">
-                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" required>
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
                                         <span class="icon is-small is-left">
                                             <i class="fas fa-search"></i>
                                         </span>
@@ -77,7 +77,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" required>
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" maxlength="100" required>
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
@@ -96,7 +96,7 @@
                                 @foreach($categories as $category)
                                     <form action="{{ route('memos.search.category') }}">
                                         @csrf
-                                        <input type="hidden" name="search_word" value="{{ $category }}">
+                                        <input type="hidden" name="search_word" value="{{ $category }}" maxlength="100">
                                         <button style="background: none; border: 0px; white-space: normal;"><span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
                                     </form>
                                 @endforeach

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -28,7 +28,7 @@
                                 <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
                                     @csrf 
                                     <div class="input-keyword">
-                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" required>
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
                                         <span class="icon is-small is-left">
                                             <i class="fas fa-search"></i>
                                         </span>
@@ -60,7 +60,9 @@
     </section>
     @if($memos->isEmpty())
         <section class="content">
-            <p>{{ Str::limit($search_word, 10) }} はヒットしませんでした。</p>
+            <div class="notification is-warning">
+                <p>{{ Str::limit($search_word, 40) }} はヒットしませんでした。</p>
+            </div>
         </section>
     @else 
         <section class="content">
@@ -77,7 +79,7 @@
                             <div class="control has-icons-left has-icons-right m-1">
                                 <form action="{{ route('memos.search.category') }}" method="GET">
                                     @csrf 
-                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" required>
+                                    <input class="input is-success" type="text" name="search_word" placeholder="カテゴリでメモを検索" maxlength="100" required>
                                     <span class="icon is-small is-left">
                                         <i class="fas fa-search"></i>
                                     </span>
@@ -194,8 +196,6 @@
                 let id = `#memo_${memos[index]['id']}`;
                 let text = sanitizeDecode(memos[index]['memo_text']);
                 $(id).text(text);
-                console.log(text);
-                console.log(id);
             }
         });
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -44,7 +44,7 @@
                     </div>
                     <div class="column is-three-fifths">
                         @if ($errors->any())
-                            <div class="has-text-danger">
+                            <div class="notification is-danger">
                                 <ul>
                                     @foreach ($errors->all() as $error)
                                         <li>{{ $error }}</li>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -71,7 +71,7 @@
                         </div>
                         <div class="column is-three-fifths">
                             @if ($errors->any())
-                                <div class="has-text-danger">
+                                <div class="notification is-danger">
                                     <ul>
                                         @foreach ($errors->all() as $error)
                                             <li>{{ $error }}</li>


### PR DESCRIPTION
メモ入力で文字数が多い場合にインサート処理できなかった不具合を改修しました。
原因は、migrationでmemoテーブルのmemo_textカラムをstring型で作成していた
事でした。string型の最大文字数は255文字だったのでmemo_textカラムをtext型へ
変更しました(text型は65535文字保有できるようです)。
各画面のナビゲーションバー部分を1つ前のブランチで変更しましたが、変更し忘れていたblade
があったので変更しました。
