### PR TITLE
カテゴリ検索でページネーションが正しく動作しないバグを修正。

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -32,7 +32,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(RouteServiceProvider::HOME);
+        return redirect()->intended(RouteServiceProvider::HOME)->with('message', 'ログインが完了しました。');
     }
 
     /**
@@ -49,6 +49,6 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerateToken();
 
-        return redirect('/');
+        return redirect('/')->with('message', 'ログアウトが完了しました。');
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -49,6 +49,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(RouteServiceProvider::HOME);
+        return redirect(RouteServiceProvider::HOME)->with('message', '会員登録が完了しました。');
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -42,7 +42,8 @@ class CategoryController extends Controller
      */
     public function store(string $categories, int $memo_id)
     {
-        $this->category->insertCategoryMemos($categories, $memo_id);
+        $insert_categories = $this->category->insertCategoryMemos($categories, $memo_id);
+        return $insert_categories;
     }
 
     /**
@@ -53,7 +54,7 @@ class CategoryController extends Controller
      */
     public function getCategories(object $memos)
     {
-        $categories = $this->category->getCategories($memos);
-        return $categories;
+        $category_arr = $this->category->getCategories($memos);
+        return $category_arr;
     }
 }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -66,14 +66,15 @@ class MemoController extends Controller
         DB::beginTransaction();
 
         try {
+            $message = "メモの投稿が完了しました。";
             $memo_id = Memo::store($user_id, $memo_data, $memo_text);
+            $memo = Memo::find($memo_id);
             $insert_categories = $this->memo->insertCategories($categories, $memo_id);
             DB::commit();
-            return view('EngineerStack.detailed_memo', compact('memo_data',
-                                            'categories', 'memo_id'));
+            return view('EngineerStack.detailed_memo', compact('memo', 'categories', 'message'));
         } catch (Exception $exception) {
             DB::rollback();
-            return redirect()->route('dashboard');
+            return redirect()->route('dashboard')->with('message', 'メモの投稿に失敗しました。');
         }
     }
 
@@ -125,17 +126,18 @@ class MemoController extends Controller
         DB::beginTransaction();
 
         try {
+            $message = 'メモの更新が完了しました。';
             $memo_text = $this->memo->getMemoText($memo_data);
             Memo::where('id', $memo_id)
                     ->update(['memo_data' => $memo_data, 'memo_text' => $memo_text]);
             $this->memo->categoriesSync($memo_id, $categories);
-            $memo_data = Memo::find($memo_id)->memo_data;
+            $memo = Memo::find($memo_id);
             DB::commit();
             return view('EngineerStack.detailed_memo'
-                    , compact('categories', 'memo_data', 'memo_id'));
+                    , compact('categories', 'memo', 'message'));
         } catch (Exception $exception) {
             DB::rollback();
-            return redirect()->route('dashboard');
+            return redirect()->route('dashboard')->with('message', 'メモの更新に失敗しました。');
         }
     }
 

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -152,17 +152,16 @@ class MemoController extends Controller
     public function show(Request $request)
     {
         $memo_id = $request->input('memo_id');
-        $memo_data = $request->input('memo_data');
         $is_owner = $this->memo->checkOwner($memo_id);
         
         if(!$is_owner) {
             return redirect()->route('dashboard');
         }
-        $title = Memo::find($memo_id)->title;
+
+        $memo = Memo::find($memo_id);
         $categories = Memo::find($memo_id)->categories->pluck('name');
-        $memo_data = Memo::find($memo_id)->memo_data;
         return view('EngineerStack.detailed_memo',
-                compact('title', 'categories', 'memo_data', 'memo_id'));
+                compact('memo', 'categories'));
     }
 
     /**

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -188,6 +188,8 @@ class MemoController extends Controller
         $search_word = $request->input('search_word');
         if(mb_strlen($search_word) > 40) {
             return redirect()->route('dashboard')->with('message', '検索語句が長すぎます。');
+        } elseif($search_word === null) {
+            return redirect()->route('dashboard')->with('message', '検索語句は必須です。');
         }
         return $this->memo->searchKeyword($request);
     }
@@ -204,6 +206,8 @@ class MemoController extends Controller
         $search_word = $request->input('search_word');
         if(mb_strlen($search_word) > 40) {
             return redirect()->route('dashboard')->with('message', '検索語句が長すぎます。');
+        } elseif($search_word === null) {
+            return redirect()->route('dashboard')->with('message', '検索語句は必須です。');
         }
         return $this->memo->searchCategory($request);
     }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -185,8 +185,8 @@ class MemoController extends Controller
      */
     public function searchKeyword(Request $request)
     {
-        $search_keyword = $request->input('search_word');
-        if(mb_strlen($search_keyword > 40)) {
+        $search_word = $request->input('search_word');
+        if(mb_strlen($search_word) > 40) {
             return redirect()->route('dashboard')->with('message', '検索語句が長すぎます。');
         }
         return $this->memo->searchKeyword($request);
@@ -201,8 +201,8 @@ class MemoController extends Controller
      */
     public function searchCategory(Request $request)
     {
-        $search_keyword = $request->input('search_word');
-        if(mb_strlen($search_keyword > 40)) {
+        $search_word = $request->input('search_word');
+        if(mb_strlen($search_word) > 40) {
             return redirect()->route('dashboard')->with('message', '検索語句が長すぎます。');
         }
         return $this->memo->searchCategory($request);

--- a/app/Http/Requests/StoreMemoRequest.php
+++ b/app/Http/Requests/StoreMemoRequest.php
@@ -29,7 +29,7 @@ class StoreMemoRequest extends FormRequest
     public function rules()
     {
         return [
-            'category_flg' => ['boolean:true'],
+            'category_flg' => ['accepted'],
             'categories' => ['required', 'string'],
             'categories_count' => ['required','integer' , 'max:5'],
             'memo_count' => ['required','integer', 'max:1000']
@@ -44,7 +44,7 @@ class StoreMemoRequest extends FormRequest
     public function messages()
     {
         return [
-            'category_flg.boolean' => 'カテゴリは20文字以内です。',
+            'category_flg.accepted' => 'カテゴリは20文字以内です。',
             'categories_count.max' => 'カテゴリの最大数は5つです。',
             'categories_count.required' => 'カテゴリは必須です。',
             'memo_count.max' => 'メモの最大入力文字を超えています。',

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -34,4 +34,17 @@ class Category extends Model
 
         return $category->id;
     }
+
+    /**
+     * Categoryレコードに紐づくMemoレコードを返す関数。
+     */
+    public function memos()
+    {
+        return $this->belongsToMany(
+            Memo::class,
+            CategoryMemo::class,
+            'category_id',
+            'memo_id'
+        );
+    }
 }

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -45,6 +45,7 @@
                 $insert_category_memos = app()->make('App\Http\Controllers\CategoryMemosController');
                 $insert_category_memos->store($memo_id, $category_id);
             }
+            return $arr_length;
         }
 
         /**

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -107,12 +107,17 @@
         public function getMemos(string $category)
         {
             $memos = collect();
-            $category_id = Category::where('name', $category)->pluck('id');
-            if($category_id->isEmpty()) { return; }
-            $memo_ids = CategoryMemo::where('category_id', $category_id)->pluck('memo_id');
+            $category_ids = Category::where('name', 'LIKE', "%$category%")->pluck('id');
+            if($category_ids->isEmpty()) { return; }
+            $memo_ids = [];
+            $category_count = count($category_ids);
+            for($index = 0; $index < $category_count; $index++) {
+                $memo_id = CategoryMemo::where('category_id', $category_ids[$index])->pluck('memo_id');
+                array_push($memo_ids, $memo_id);
+            }
             $memo_count = count($memo_ids);
             for($index = 0; $index < $memo_count; $index++) {
-                $memo = Memo::where('id', $memo_ids[$index])->get();
+                $memo = Memo::find($memo_ids[$index]);
                 $memos = $memos->concat($memo);
             }
             return $memos;

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -132,7 +132,7 @@
             $current_page = $request->input('page');
             $sort = $request->input('sort');
             $all_memos = Memo::where('user_id', $user_id)->get();
-            $categories = $this->getCategories($all_memos);
+            $categories = $this->getCategories($all_memos)->slice(0, 15);
             if($sort == "ascend") {
                 $memos = Memo::where('user_id', $user_id)
                         ->orderBy('updated_at', 'desc')
@@ -171,7 +171,7 @@
             $search_word = $category;
             $all_memos = Memo::where('user_id', $user_id)->get();
             $hit_memos = $this->getMemos($category);
-            $categories = $this->getCategories($all_memos);
+            $categories = $this->getCategories($all_memos)->slice(0, 15);
             $current_page = $request->input('page');
             if(empty($current_page)) {
                 $current_page = 1;

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -20,7 +20,7 @@
         public function insertCategories(string $categories, int $memo_id)
         {
             $insert_categories = app()->make('App\Http\Controllers\CategoryController');
-            $insert_categories->store($categories, $memo_id);
+            return $insert_categories->store($categories, $memo_id);
         }
 
         /**

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -117,6 +117,7 @@
             }
             $memo_count = count($memo_ids);
             for($index = 0; $index < $memo_count; $index++) {
+                //checkownerしてない
                 $memo = Memo::find($memo_ids[$index]);
                 $memos = $memos->concat($memo);
             }
@@ -188,11 +189,12 @@
             $all_memos = Memo::where('user_id', $user_id)->get();
             $categories = $this->getCategories($all_memos)->slice(0, 15);
             $memo_collection = $this->getMemos($category, $sort);
+            
             if(empty($current_page)) {
                 $current_page = 1;
             }
 
-            if($memo_collection !== null) {
+            if($memo_collection != null) {
                 $total_pages = (int)ceil(count($memo_collection)/6);
                 $memos = $memo_collection->forPage($current_page, 6);
             } else {

--- a/database/factories/MemoFactory.php
+++ b/database/factories/MemoFactory.php
@@ -23,24 +23,24 @@ class MemoFactory extends Factory
      */
     public function definition()
     {
+        $text = $this->faker->realText(50);
         $memo_data = "{
                         \"time\": \"{$this->faker->unixTime}\",
                         \"blocks\": [
                             {
                                 \"id\": \"0{$this->faker->unixTime}\",
                                 \"data\": {
-                                    \"text\": \"{$this->faker->realText(50)}\"
+                                    \"text\": \"{$text}\"
                                 },
                                 \"type\": \"paragraph\"
                             }
                         ],
                         \"version\": \"2.22.2\"
                     }";
-                
 
         return [
             'user_id' => 1,
-            'title' => $this->faker->sentence,
+            'memo_text' => $text,
             'memo_data' => $memo_data,
             'created_at' => now(),
             'updated_at' => now()

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        Memo::factory(1)->create();
-        Category::factory(5)->create();
+        Memo::factory()->count(10)->create();
+        //Category::factory(5)->create();
     }
 }

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -75,7 +75,7 @@
                         <form action="{{ route('memos.search.category') }}">
                             @csrf
                             <input type="hidden" name="search_word" value="{{ $category }}">
-                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-link is-size-3"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
+                            <button style="background: none; border: 0px; white-space: normal;"><span class="tag is-link is-size-6"><i class="fas fa-tape"></i>{{ Str::limit($category, 40) }}</span><br></button>
                         </form>
                     </div>
                 @endforeach

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -59,7 +59,7 @@
         </nav>
     </section>
     <section class="content">
-        <h4 class="notification is-primary">メモの削除が完了しました。</h4>
+        <p class="notification is-primary">メモの削除が完了しました。</p>
     </section>
     <section class="footer">
         <div class="columns">

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -63,8 +63,8 @@
             <div class="column">
             </div>
             <div class="column is-three-fifths has-background-white p-5">
-                <div class="created_at">
-                    <span id="created_at"></span>
+                <div class="updated_at">
+                    <span>{{ $memo->updated_at->format("Y年m月d日 H時i分s秒") }} 作成</span>
                 </div>
                 <div class="category">
                     <i class="fas fa-tape"></i><span id="categories"></span>
@@ -83,7 +83,7 @@
                             </div>
                             <div class="dropdown-menu" id="dropdown-menu3" role="menu">
                                 <div class="dropdown-content">
-                                    <a href="{{ $memo_id }}/edit" class="dropdown-item has-text-left">メモを編集する</a>
+                                    <a href="{{ $memo->id }}/edit" class="dropdown-item has-text-left">メモを編集する</a>
                                     <hr class="dropdown-divider">
                                     <button id="delete_memo" class="dropdown-item has-text-left has-text-danger" style="background: none; border: 0px; white-space: normal;">
                                         メモを削除する
@@ -104,9 +104,9 @@
                                                 <button class="delete" aria-label="close"></button>
                                             </header>
                                             <footer class="modal-card-foot">
-                                                <form action="{{ $memo_id }}/destroy" method="POST">
+                                                <form action="{{ $memo->id }}/destroy" method="POST">
                                                     @csrf 
-                                                    <input type="hidden" name="memo_id" value="{{ $memo_id }}">
+                                                    <input type="hidden" name="memo_id" value="{{ $memo->id }}">
                                                     <button class="button is-danger"><i class="fas fa-trash-alt"></i>削除</button>
                                                 </form>
                                                 <button id="modal-close" class="button">キャンセル</button>
@@ -155,12 +155,8 @@
     <script>
         $(function () {
             let categories = @json($categories);
-            let memoData = @json($memo_data);
+            let memoData = @json($memo->memo_data);
             memoData = JSON.parse(memoData);
-            let created_at = memoData.time;
-            created_at = new Date(created_at);
-            created_at = getStringFromDate(created_at);
-            $('#created_at').text(created_at);
             $('#categories').text(categories);
 
             $(".settings").click(function() {
@@ -195,27 +191,6 @@
                 },
             });
         });
-
-        function getStringFromDate(date) {
-        
-            let year_str = date.getFullYear();
-            let month_str = 1 + date.getMonth();
-            let day_str = date.getDate();
-            let hour_str = date.getHours();
-            let minute_str = date.getMinutes();
-            let second_str = date.getSeconds();
-            
-            
-            format_str = 'YYYY年MM月DD日 hh時mm分ss秒に投稿';
-            format_str = format_str.replace(/YYYY/g, year_str);
-            format_str = format_str.replace(/MM/g, month_str);
-            format_str = format_str.replace(/DD/g, day_str);
-            format_str = format_str.replace(/hh/g, hour_str);
-            format_str = format_str.replace(/mm/g, minute_str);
-            format_str = format_str.replace(/ss/g, second_str);
-            
-            return format_str;
-        };
     </script>
 </body>
 </html>

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -58,6 +58,13 @@
             </div>
         </nav>
     </section>
+    <section class="message">
+        @isset($message)
+            <div class="notification is-success has-text-centered">
+                <p>{{ $message }}</p>
+            </div>
+        @endisset
+    </section>
     <section class="content has-background-light pt-5 pb-5">
         <div class="columns mt-5">
             <div class="column">

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -159,6 +159,8 @@
                 onChange: function(event) {
                     let text = $('.ce-block').text();
                     let code = $('.cdx-input').val();
+                    console.log(code);
+                    console.log(text);
                     if(code === undefined) {
                         code = '';
                     }

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -67,10 +67,10 @@
                         <h4 class="is-size-4">メモを編集する</h4>
                         <div class="errors">
                             @if ($errors->any())
-                                <div class="notification is-danger">
+                                <div class="notification is-danger has-text-centered">
                                     <ul>
                                         @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
+                                            <p>{{ $error }}</p>
                                         @endforeach
                                     </ul>
                                 </div>
@@ -81,8 +81,9 @@
                         @csrf 
                         <input type="hidden" id="memo_data" name="memo_data">
                         <input type="hidden" name="memo_id" value="{{ $memo->id }}">
-                        <input type="hidden" id="categories_count" name="categories_count">
-                        <input type="hidden" id="memo_count" name="memo_count">
+                        <input type="hidden" id="categories_count" name="categories_count" value="1">
+                        <input type="hidden" id="memo_count" name="memo_count" value="1">
+                        <input type="hidden" id="category_flg" name="category_flg" value="true">
                         <div class="field">
                             <label for="comment">カテゴリ<br><span class="has-text-danger">*必須 最大5個 1カテゴリ30文字まで</span></label><br>
                             <span class="has-text-primary" id="count_category">残り5個入力可能</span>
@@ -97,7 +98,7 @@
                         </div>
                         <div class="memo">
                             <label for="editorjs">メモ<br><span class="has-text-danger">*必須</span></label>
-                            <div id="editorjsCnt"></div>
+                            <div id="disp_size"></div>
                             <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
                         </div>
                         <button id="post_memo" class="button is-primary m-2">
@@ -155,19 +156,21 @@
                     quote: Quote,
                     code: CodeTool,
                 },
+                onChange: function(event) {
+                    let text = $('.ce-block').text();
+                    let code = $('.cdx-input').val();
+                    if(code === undefined) {
+                        code = '';
+                    }
+                    let charCnt = (text + code).length;
+                    let dispCntChar = `${charCnt}文字入力されています。`;
+                    $('#disp_size').text(dispCntChar);
+                    $('#memo_count').val(charCnt);
+                },
                 data: memoData,
             });
 
             $("#post_memo").click(function() {
-                let editorjsTxt = getEditorjsTxt();
-                let cntTxt = getEditorjsCnt(editorjsTxt);
-                let categories = $('#category').val();
-                let categoriesArr = separateText(',', categories);
-                let categories_count = categoriesArr.length;
-
-                $('#categories_count').val(categories_count);
-                $('#memo_count').val(cntTxt);
-
                 editor.save().then((outputData) => {
                     $('#memo_data').val(JSON.stringify(outputData));
                 }).catch((error) => {
@@ -176,14 +179,29 @@
             });
 
             $("#category").keyup(function() {
+                let flgArr = []
                 const separator = ",";
                 let inputText = $(this).val();
                 let textToArray = separateText(separator, inputText);
+                countCategory(textToArray);
+                textToArray.forEach(function(element, index) {
+                    let length = Math.max(...element.split(" ").map (element => element.length));
+                    if(length <= 20) {
+                        flgArr[index] = true;
+                    } else {
+                        flgArr[index] = false;
+                    }
+                });
                 let dispText = arrayToText(textToArray);
                 let tags = pushTag(textToArray);
                 $("#disp_category").html(tags);
                 let arrayLength = textToArray.length;
                 $('#categories_count').val(arrayLength);
+                if(flgArr.includes(false)) {
+                    $('#category_flg').val(false);
+                } else {
+                    $('#category_flg').val(true);
+                }
             });
         });
 

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -58,6 +58,18 @@
             </div>
         </nav>
     </section>
+    <section class="message">
+        @isset($message)
+            <div class="notification is-success has-text-centered">
+                <p>{{ $message }}</p>
+            </div>
+        @endisset
+        @if (session('message'))
+            <div class="notification is-success has-text-centered">
+                {{ session('message') }}
+            </div>
+        @endif
+    </section>
     @if($memos->isEmpty())
         <section class="content">
             <p>まだメモは投稿されていません。</p>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -110,13 +110,13 @@
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3" style="min-width: 300px;">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px; max-height: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     <span class="tag"><i class="fas fa-tape"></i>{{ Str::limit($category, 15) }}</span>
                                 @endforeach
                             </div><br>
-                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word">
+                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word;">
                             </div><br>
                             <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
@@ -186,10 +186,15 @@
             const memosLength = memos['data'].length;
             for(let index = 0; index < memosLength; index++) {
                 const id = `#memo_${memos['data'][index]['id']}`;
-                const text = sanitizeDecode(memos['data'][index]['memo_text']);
+                let text = sanitizeDecode(memos['data'][index]['memo_text']);
+                text = truncate(text);
                 $(id).text(text);
             }
         });
+
+        function truncate(str){
+            return str.length <= 100 ? str: (str.substr(0, 100)+"...");
+        }
 
         function sanitizeDecode(text) {
             return text.replace(/&lt;/g, '<')

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -139,7 +139,7 @@
                                 </form>
                             </div>
                             <div class="post-time">
-                                <p>{{ $memo->created_at->diffForHumans() }}</p>
+                                <p>{{ $memo->created_at->format('Y年m月d日 H時i分s秒 投稿') }}</p>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -197,10 +197,8 @@
                 $('#categories_count').val(arrayLength);
                 if(flgArr.includes(false)) {
                     $('#category_flg').val(false);
-                    console.log(false);
                 } else {
                     $('#category_flg').val(true);
-                    console.log(true);
                 }
             });
         });

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -70,10 +70,10 @@
                         @csrf
                         <div class="errors">
                             @if ($errors->any())
-                                <div class="notification is-danger">
+                                <div class="notification is-danger has-text-centered">
                                     <ul>
                                         @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
+                                            <p>{{ $error }}</p>
                                         @endforeach
                                     </ul>
                                 </div>
@@ -153,9 +153,6 @@
                     quote: Quote,
                     code: CodeTool
                 },
-                data: {
-
-                },
                 onChange: function(event) {
                     let text = $('.ce-block').text();
                     let code = $('.cdx-input').val();
@@ -182,6 +179,7 @@
                 const separator = ",";
                 let inputText = $(this).val();
                 let textToArray = separateText(separator, inputText);
+                countCategory(textToArray);
                 textToArray.forEach(function(element, index) {
                     let length = Math.max(...element.split(" ").map (element => element.length));
                     if(length <= 20) {

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -58,6 +58,18 @@
             </div>
         </nav>
     </section>
+    <section class="message">
+        @isset($message)
+            <div class="notification is-success has-text-centered">
+                <p>{{ $message }}</p>
+            </div>
+        @endisset
+        @if (session('message'))
+            <div class="notification is-danger has-text-centered">
+                {{ session('message') }}
+            </div>
+        @endif
+    </section>
     <section class="content">
         <div class="input-memo p-5">
             <div class="columns">
@@ -82,6 +94,7 @@
                         <div class="field">
                             <label for="comment">カテゴリ <span class="has-text-danger">半角カンマ「,」で区切って入力</span><br><span class="has-text-danger">*必須 最大5個 カテゴリ1つにつき20文字以内</span></label><br>
                             <span class="has-text-primary" id="count_category">残り5個入力可能</span>
+                            <span class="has-text-danger" id="flag"></span><br>
                             <span class="is-primary" id="disp_category"></span>
                             <div class="control has-text-centered">
                                 <div class="field">
@@ -93,7 +106,7 @@
                         </div>
                         <div class="editor_field">
                             <label for="editor">メモ<br><span class="has-text-danger">*必須 1000文字以内</span></label>
-                            <div id="disp_size"></div>
+                            <div class="disp_size" id="disp_size"></div>
                             <div class="editor_wrapper p-5">
                                 <div id="editorjs" style="border: 1px solid #00d1b2; border-radius: 4px;"></div>
                                 <input type="hidden" id="categories_count" name="categories_count">
@@ -161,6 +174,13 @@
                     }
                     let charCnt = (text + code).length;
                     let dispCntChar = `${charCnt}文字入力されています。`;
+                    if(charCnt > 1000) {
+                        $('#disp_size').addClass('has-text-danger');
+                        $('#disp_size').removeClass('has-text-primary');
+                    } else {
+                        $('#disp_size').removeClass('has-text-danger');
+                        $('#disp_size').addClass('has-text-primary');
+                    }
                     $('#disp_size').text(dispCntChar);
                     $('#memo_count').val(charCnt);
                 }
@@ -195,8 +215,10 @@
                 $('#categories_count').val(arrayLength);
                 if(flgArr.includes(false)) {
                     $('#category_flg').val(false);
+                    $('#flag').text('20文字以上のカテゴリは設定できません。');
                 } else {
                     $('#category_flg').val(true);
+                    $('#flag').text('');
                 }
             });
         });

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -145,18 +145,82 @@
                         <ul class="pagination-list">
                             @if ($current_page == 1)
                                 @if ($current_page == $total_pages)
-                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
+                                    <li>
+                                        <form action="{{ route('memos.search.category') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                        </form>
+                                    </li>
                                 @else 
-                                    <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
-                                    <li><a class="pagination-next" href="search?page={{ $current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
+                                    <li>
+                                        <form action="{{ route('memos.search.category') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                        </form>
+                                    </li>
+                                    <li>
+                                        <form action="{{ route('memos.search.category') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page + 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
+                                        </form>
+                                    </li>
                                 @endif
                             @elseif($current_page == $total_pages)
-                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}&sort={{ $sort }}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
+                                <li>
+                                    <form action="{{ route('memos.search.category') }}" method="get">
+                                        @csrf
+                                        <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                        <input type="hidden" value="{{ $sort }}" name="sort">
+                                        <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                    </form>
+                                </li>
+                                <li>
+                                    <form action="{{ route('memos.search.category') }}" method="get">
+                                        @csrf
+                                        <input type="hidden" value="{{ $current_page }}" name="page">
+                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                        <input type="hidden" value="{{ $sort }}" name="sort">
+                                        <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                    </form>
+                                </li>
                             @else 
-                                <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}&sort={{ $sort }}">前のページ</a></li>
-                                <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
-                                <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
+                                <li>
+                                    <form action="{{ route('memos.search.category') }}" method="get">
+                                        @csrf
+                                        <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                        <input type="hidden" value="{{ $sort }}" name="sort">
+                                        <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                    </form>
+                                </li>
+                                <li>
+                                    <form action="{{ route('memos.search.category') }}" method="get">
+                                        @csrf
+                                        <input type="hidden" value="{{ $current_page }}" name="page">
+                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                        <input type="hidden" value="{{ $sort }}" name="sort">
+                                        <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                    </form>
+                                </li>
+                                <li>
+                                    <form action="{{ route('memos.search.category') }}" method="get">
+                                        @csrf
+                                        <input type="hidden" value="{{ $current_page + 1 }}" name="page">
+                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                        <input type="hidden" value="{{ $sort }}" name="sort">
+                                        <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
+                                    </form>
+                                </li>
                             @endif
                         </ul>
                     </nav>
@@ -188,13 +252,13 @@
                 crossorigin="anonymous"></script>
     <script>
         $(function () {
-            const memos = @json($memos);
-            const currentPage = parseInt(@json($current_page));
-            const memosLength = Object.keys(memos).length;
-            const indexStart = (currentPage - 1) * 6;
-            for(let index = indexStart; index < indexStart + memosLength; index++) {
-                let id = `#memo_${memos[index]['id']}`;
-                let text = sanitizeDecode(memos[index]['memo_text']);
+            let memos = @json($memos);
+            console.log(memos);
+            memos = JSON.parse(JSON.stringify(memos));
+            
+            for(let key in memos) {
+                let id = `#memo_${memos[key]['id']}`;
+                let text = memos[key]['memo_text'];
                 text = truncate(text);
                 $(id).text(text);
             }

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -148,7 +148,7 @@
                                     <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
                                 @else 
                                     <li><a class="pagination-link is-current" aria-current="page" href="search?page={{$current_page}}&search_word={{$search_word}}&sort={{ $sort }}">{{ $current_page }}</a></li>
-                                    <li><a class="pagination-next" href="search?page={{$current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
+                                    <li><a class="pagination-next" href="search?page={{ $current_page + 1}}&search_word={{$search_word}}&sort={{ $sort }}">次のページ</a></li>
                                 @endif
                             @elseif($current_page == $total_pages)
                                 <li><a class="pagination-previous" href="search?page={{$current_page - 1}}&search_word={{$search_word}}&sort={{ $sort }}">前のページ</a></li>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -112,7 +112,7 @@
                 </div>
                 <div class="memos columns is-multiline">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3" style="min-width: 300px">
+                        <div class="memo column is-5 box m-3" style="min-width: 300px; max-height: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     @if($category === $search_word)
@@ -122,7 +122,7 @@
                                     @endif
                                 @endforeach
                             </div><br>
-                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word">
+                            <div id="memo_{{ $memo->id }}" style="overflow-wrap: break-word;">
                             </div><br>
                             <div class="memo-data mb-3">
                                 <form action="{{ route('memos.show') }}" method="POST">
@@ -195,9 +195,14 @@
             for(let index = indexStart; index < indexStart + memosLength; index++) {
                 let id = `#memo_${memos[index]['id']}`;
                 let text = sanitizeDecode(memos[index]['memo_text']);
+                text = truncate(text);
                 $(id).text(text);
             }
         });
+
+        function truncate(str){
+            return str.length <= 100 ? str: (str.substr(0, 100)+"...");
+        }
 
         function sanitizeDecode(text) {
             return text.replace(/&lt;/g, '<')

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -141,10 +141,50 @@
             </div>
             <div class="columns">
                 <div class="column">
-                    <nav class="pagination is-centered" role="navigation" aria-label="pagination">
-                        <ul class="pagination-list">
-                            @if ($current_page == 1)
-                                @if ($current_page == $total_pages)
+                    @if($is_search_category)
+                        <nav class="pagination is-centered" role="navigation" aria-label="pagination">
+                            <ul class="pagination-list">
+                                @if ($current_page == 1)
+                                    @if ($current_page == $total_pages)
+                                        <li>
+                                            <form action="{{ route('memos.search.category') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                            </form>
+                                        </li>
+                                    @else 
+                                        <li>
+                                            <form action="{{ route('memos.search.category') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                            </form>
+                                        </li>
+                                        <li>
+                                            <form action="{{ route('memos.search.category') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page + 1 }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
+                                            </form>
+                                        </li>
+                                    @endif
+                                @elseif($current_page == $total_pages)
+                                    <li>
+                                        <form action="{{ route('memos.search.category') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                        </form>
+                                    </li>
                                     <li>
                                         <form action="{{ route('memos.search.category') }}" method="get">
                                             @csrf
@@ -155,6 +195,15 @@
                                         </form>
                                     </li>
                                 @else 
+                                    <li>
+                                        <form action="{{ route('memos.search.category') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                        </form>
+                                    </li>
                                     <li>
                                         <form action="{{ route('memos.search.category') }}" method="get">
                                             @csrf
@@ -174,56 +223,93 @@
                                         </form>
                                     </li>
                                 @endif
-                            @elseif($current_page == $total_pages)
-                                <li>
-                                    <form action="{{ route('memos.search.category') }}" method="get">
-                                        @csrf
-                                        <input type="hidden" value="{{ $current_page - 1 }}" name="page">
-                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
-                                        <input type="hidden" value="{{ $sort }}" name="sort">
-                                        <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
-                                    </form>
-                                </li>
-                                <li>
-                                    <form action="{{ route('memos.search.category') }}" method="get">
-                                        @csrf
-                                        <input type="hidden" value="{{ $current_page }}" name="page">
-                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
-                                        <input type="hidden" value="{{ $sort }}" name="sort">
-                                        <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
-                                    </form>
-                                </li>
-                            @else 
-                                <li>
-                                    <form action="{{ route('memos.search.category') }}" method="get">
-                                        @csrf
-                                        <input type="hidden" value="{{ $current_page - 1 }}" name="page">
-                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
-                                        <input type="hidden" value="{{ $sort }}" name="sort">
-                                        <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
-                                    </form>
-                                </li>
-                                <li>
-                                    <form action="{{ route('memos.search.category') }}" method="get">
-                                        @csrf
-                                        <input type="hidden" value="{{ $current_page }}" name="page">
-                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
-                                        <input type="hidden" value="{{ $sort }}" name="sort">
-                                        <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
-                                    </form>
-                                </li>
-                                <li>
-                                    <form action="{{ route('memos.search.category') }}" method="get">
-                                        @csrf
-                                        <input type="hidden" value="{{ $current_page + 1 }}" name="page">
-                                        <input type="hidden" value="{{ $search_word }}" name="search_word">
-                                        <input type="hidden" value="{{ $sort }}" name="sort">
-                                        <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
-                                    </form>
-                                </li>
-                            @endif
-                        </ul>
-                    </nav>
+                            </ul>
+                        </nav>
+                    @else 
+                        <nav class="pagination is-centered" role="navigation" aria-label="pagination">
+                            <ul class="pagination-list">
+                                @if ($current_page == 1)
+                                    @if ($current_page == $total_pages)
+                                        <li>
+                                            <form action="{{ route('memos.search') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                            </form>
+                                        </li>
+                                    @else 
+                                        <li>
+                                            <form action="{{ route('memos.search') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                            </form>
+                                        </li>
+                                        <li>
+                                            <form action="{{ route('memos.search') }}" method="get">
+                                                @csrf
+                                                <input type="hidden" value="{{ $current_page + 1 }}" name="page">
+                                                <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                                <input type="hidden" value="{{ $sort }}" name="sort">
+                                                <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
+                                            </form>
+                                        </li>
+                                    @endif
+                                @elseif($current_page == $total_pages)
+                                    <li>
+                                        <form action="{{ route('memos.search') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                        </form>
+                                    </li>
+                                    <li>
+                                        <form action="{{ route('memos.search') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                        </form>
+                                    </li>
+                                @else 
+                                    <li>
+                                        <form action="{{ route('memos.search') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page - 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-previous" aria-current="page" value="前のページ">
+                                        </form>
+                                    </li>
+                                    <li>
+                                        <form action="{{ route('memos.search') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-link is-current" aria-current="page" value="{{ $current_page }}">
+                                        </form>
+                                    </li>
+                                    <li>
+                                        <form action="{{ route('memos.search') }}" method="get">
+                                            @csrf
+                                            <input type="hidden" value="{{ $current_page + 1 }}" name="page">
+                                            <input type="hidden" value="{{ $search_word }}" name="search_word">
+                                            <input type="hidden" value="{{ $sort }}" name="sort">
+                                            <input type="submit" class="pagination-next" aria-current="page" value="次のページ">
+                                        </form>
+                                    </li>
+                                @endif
+                            </ul>
+                        </nav>
+                    @endif
                 </div> 
             </div>
         </section>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -60,7 +60,7 @@
     </section>
     @if($memos->isEmpty())
         <section class="content">
-            <div class="notification is-warning">
+            <div class="notification is-warning has-text-centered">
                 <p>{{ Str::limit($search_word, 40) }} はヒットしませんでした。</p>
             </div>
         </section>
@@ -133,7 +133,7 @@
                                 </form>
                             </div>
                             <div class="post-time">
-                                <p>{{ $memo->created_at->diffForHumans() }}</p>
+                                <p>{{ $memo->created_at->format('Y年m月d日 H時i分s秒 投稿') }}</p>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -44,10 +44,10 @@
                     </div>
                     <div class="column is-three-fifths">
                         @if ($errors->any())
-                            <div class="notification is-danger">
+                            <div class="notification is-danger has-text-centered">
                                 <ul>
                                     @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
+                                        <p>{{ $error }}</p>
                                     @endforeach
                                 </ul>
                             </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -36,6 +36,13 @@
             </div>
         </nav>
     </section>
+    <section class="message">
+        @if (session('message'))
+            <div class="notification is-success has-text-centered">
+                {{ session('message') }}
+            </div>
+        @endif
+    </section>
     <section class="content has-background-primary m-5 p-5">
         <div class="introduction">
             <div class="columns">
@@ -71,10 +78,10 @@
                         </div>
                         <div class="column is-three-fifths">
                             @if ($errors->any())
-                                <div class="notification is-danger">
+                                <div class="notification is-danger has-text-centered">
                                     <ul>
                                         @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
+                                            <p>{{ $error }}</p>
                                         @endforeach
                                     </ul>
                                 </div>


### PR DESCRIPTION
カテゴリ検索でページネーションが正しく動作しない不具合を修正しました。
原因は、bladeにおいてパラメーターを単純にaタグのhref属性にて渡していたためでした。
formに各パラメータをhidden属性でセットして送信することで、ページネーションが正しく動作しない
問題は解決しました。
バグ修正ではないですが、カテゴリ一覧において各カテゴリのfont-sizeをis-3からis-6に変更し
小さくしました。