### PR TITLE
多重送信への対策を実装。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -68,6 +68,7 @@ class MemoController extends Controller
             $memo_id = Memo::store($user_id, $memo);
             $memo = Memo::find($memo_id);
             $insert_categories = $this->memo->insertCategories($categories, $memo_id);
+            $request->session()->regenerateToken();
             if($insert_categories > 5) {
                 DB::rollback();
                 return redirect()->route('memos.get.input')->with('message', 'カテゴリの最大数は5つです。');
@@ -130,6 +131,7 @@ class MemoController extends Controller
             Memo::where('id', $memo_id)
                     ->update(['memo' => $memo]);
             $categories_count = $this->memo->categoriesSync($memo_id, $categories);
+            $request->session()->regenerateToken();
 
             if($categories_count > 5) {
                 DB::rollback();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -56,6 +56,7 @@ class UserController extends Controller
             $user = User::find(Auth::id());
             $message = "アカウント名を更新しました。";
             DB::commit();
+            $request->session()->regenerateToken();
             return view('EngineerStack.account', compact('message', 'user'));
         } catch(Exception $exception) {
             DB::rollback();
@@ -84,6 +85,7 @@ class UserController extends Controller
             'new_password' => 'required|min:8|max:16|confirmed',
         ]);
         $user->update(['password' => bcrypt($new_password)]);
+        $request->session()->regenerateToken();
         return redirect()->route('user.show')
                 ->with('message', 'パスワードを変更しました。');
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@ Route::get('/dashboard', [MemoController::class, 'index'])->middleware(['auth'])
 
 Route::prefix('users')->group(function () {
     Route::get('show', [UserController::class, 'show'])->name('user.show');
-    Route::post('update_name', [UserController::class, 'updateAccountName'])->name('user.update.name');
+    Route::post('update_name', [UserController::class, 'updateAccountName'])->middleware('throttle:3, 1')->name('user.update.name');
     Route::get('update_email_form', function (){
         return view('EngineerStack.change-email-form');
     })->middleware('auth')->name('user.update.email.form');
@@ -22,7 +22,7 @@ Route::prefix('users')->group(function () {
     Route::get('update_password_form', function (){
         return view('EngineerStack.change-password-form');
     })->middleware('auth')->name('user.update.password.form');
-    Route::post('update_password', [UserController::class, 'updatePassword'])->name('user.update.password');
+    Route::post('update_password', [UserController::class, 'updatePassword'])->middleware('throttle:3, 1')->name('user.update.password');
     Route::get('reset/{token}', [ChangeEmailController::class, 'reset'])->name('email.reset');
     Route::post('destroy', [UserController::class, 'destroy'])->name('user.destroy');
 });
@@ -30,7 +30,7 @@ Route::prefix('users')->group(function () {
 Route::prefix('memos')->group(function () {
     Route::get('index', [MemoController::class, 'index'])->name('memos.index');
     Route::get('create', [MemoController::class, 'create'])->name('memos.create');
-    Route::post('store', [MemoController::class, 'store'])->name('memos.store');
+    Route::post('store', [MemoController::class, 'store'])->middleware('throttle:3, 1')->name('memos.store');
     Route::get('{memo_id}/edit', [MemoController::class, 'edit'])->name('memos.edit');
     Route::post('update', [MemoController::class, 'update'])->name('memos.update');
     Route::post('{memo_id}/destroy', [MemoController::class, 'destroy'])->name('memos.destroy');


### PR DESCRIPTION
多重送信対策を実装した。2つ実装し、
1.各コントローラーのデータの作成・更新にかかわる箇所でトークンの再作成を行った。
2.各ルーティングでのデータの作成・更新にかかわる箇所に1分間で3回以上のリクエストを
行った場合に、エラーを出すように設定。
以上の2つを実装した。