### PR TITLE
カテゴリの不具合を修正。

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -72,6 +72,8 @@ class MemoController extends Controller
             if($insert_categories > 5) {
                 DB::rollback();
                 return redirect()->route('memos.get.input')->with('message', 'カテゴリの最大数は5つです。');
+            } else if($insert_categories < 0) {
+                return redirect()->route('memos.get.input')->with('message', 'カテゴリの最大文字数を超えています。');
             }
             DB::commit();
             return view('EngineerStack.detailed_memo', compact('memo', 'categories', 'message'));
@@ -136,6 +138,8 @@ class MemoController extends Controller
             if($categories_count > 5) {
                 DB::rollback();
                 return redirect()->route('dashboard')->with('alert', 'メモの更新に失敗しました。');
+            } else if($categories_count < 0) {
+                return redirect()->route('memos.get.input')->with('message', 'カテゴリの最大文字数を超えています。');
             }
 
             $memo = Memo::find($memo_id);

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -16,6 +16,11 @@
             $categories_arr = explode($separater, $categories);
             $categories_arr = array_filter($categories_arr, "strlen");
             $categories_arr = array_map("trim", $categories_arr);
+            array_filter($categories_arr, function($val) {
+                if(mb_strlen($val) > 20){
+                    return false;
+                }
+            });
             return $categories_arr;
         }
 

--- a/app/Services/MemoService.php
+++ b/app/Services/MemoService.php
@@ -19,6 +19,15 @@
          */
         public function insertCategories(string $categories, int $memo_id)
         {
+            $categories_arr = $this->strToArr($categories);
+            $category_check = array_filter($categories_arr, function($val) {
+                if(mb_strlen($val) > 20){
+                    return false;
+                }
+            });
+            if($category_check == false) {
+                return -1;
+            }
             $insert_categories = app()->make('App\Http\Controllers\CategoryController');
             return $insert_categories->store($categories, $memo_id);
         }
@@ -59,6 +68,14 @@
         public function categoriesSync(int $memo_id, string $categories)
         {
             $categories_arr = $this->strToArr($categories);
+            $category_check = array_filter($categories_arr, function($val) {
+                if(mb_strlen($val) > 20){
+                    return false;
+                }
+            });
+            if($category_check == false) {
+                return -1;
+            }
             $arr_length = count($categories_arr);
             $category_ids = [];
             for($index = 0; $index < $arr_length; $index++) {
@@ -78,6 +95,8 @@
 
         /**
          * カテゴリー文字列を配列に変換して返す。
+         * カテゴリの文字数が20文字を超えていた場合、
+         * 処理を中断する。
          * @param string: $categories
          * @return array: $categories_arr
          */
@@ -87,6 +106,11 @@
             $categories_arr = explode($separater, $categories);
             $categories_arr = array_filter($categories_arr, "strlen");
             $categories_arr = array_map("trim", $categories_arr);
+            array_filter($categories_arr, function($val) {
+                if(mb_strlen($val) > 20){
+                    return false;
+                }
+            });
             return $categories_arr;
         }
 


### PR DESCRIPTION
カテゴリの20文字を超過していた場合でも処理が通ってしまう不具合を修正。
カテゴリに何文字でも挿入出来てしまっていたので、20文字を超えたら通知を
表示して処理を行わないように実装した。
次はコードのリファクタリングを行う。
![コメント 2022-02-01 115323](https://user-images.githubusercontent.com/42739038/151906600-d07932a8-11cd-4e1b-9bde-9c4e866f7ea4.jpg)

