### PR TITLE
キーワード検索の不具合を修正。

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
 use App\Models\Category;
-use App\Models\Memo;
-use Illuminate\Http\Request;
 use App\Services\CategoryService;
 
 class CategoryController extends Controller

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Http\Requests\StoreMemoRequest;
 use App\Models\Memo;
-use App\Models\Category;
 use App\Services\MemoService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Pagination\Paginator;
@@ -157,6 +156,8 @@ class MemoController extends Controller
         $search_word = $request->input('search_word');
         $current_page = $request->input('page');
         $sort = $request->input('sort');
+
+        if($current_page === null) $current_page = 1;
         if(mb_strlen($search_word) > 40) {
             return redirect()->route('dashboard')->with('message', '検索語句が長すぎます。');
         } elseif($search_word === null) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -77,7 +77,7 @@ class UserController extends Controller
         }
         $new_password = $request->input('new_password');
         $validated = $request->validate([
-            'new_password' => 'required|min:8|max:16|confirmed',
+            'new_password' => 'required|min:8|max:50|confirmed',
         ]);
         $user->update(['password' => bcrypt($new_password)]);
         $request->session()->regenerateToken();

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -16,11 +16,6 @@
             $categories_arr = explode($separater, $categories);
             $categories_arr = array_filter($categories_arr, "strlen");
             $categories_arr = array_map("trim", $categories_arr);
-            array_filter($categories_arr, function($val) {
-                if(mb_strlen($val) > 20){
-                    return false;
-                }
-            });
             return $categories_arr;
         }
 

--- a/resources/views/EngineerStack/change-password-form.blade.php
+++ b/resources/views/EngineerStack/change-password-form.blade.php
@@ -102,7 +102,7 @@
                         @csrf 
                         <label for="old-password">現在のパスワードを入力してください。</label>
                         <input type="password" name="old_password" id="old-password" class="input is-hovered mt-3">
-                        <label for="new-password">新しいパスワードを設定してください。</label>
+                        <label for="new-password">新しいパスワードを設定してください。<br><span class="has-text-danger">*8文字以上50文字以下の半角英数字</span></label>
                         <input type="password" name="new_password" id="new-password" class="input is-hovered mt-3">
                         <label for="new-password-confirmation">新しいパスワードの確認</label>
                         <input type="password" name="new_password_confirmation" id="new-password-confirmation" class="input is-hovered mt-3">


### PR DESCRIPTION
リファクタリングの際に、ページ数の変数が設定されていない場合(検索結果にとんだ直後の場合)
にコントローラーでページ数の変数をnullか判定せず使用していたためエラーが発生した。
nullの場合には、ページ数の変数に1(とんだ直後のページ数)を設定するようにした。
カテゴリーの文字数バリデーションに不具合を発見したので修正。
全体的に関数の説明(コメント)が雑なので、修正する。