### PR TITLE
ホーム画面の改修やフッター要素の追加など。

### DIFF
--- a/app/Models/Memo.php
+++ b/app/Models/Memo.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;

--- a/resources/views/EngineerStack/account.blade.php
+++ b/resources/views/EngineerStack/account.blade.php
@@ -146,8 +146,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/account.blade.php
+++ b/resources/views/EngineerStack/account.blade.php
@@ -89,7 +89,7 @@
                     <p class="is-size-4 is-text-weight-bold">アカウント設定</p>
                 </div>
                 <div class="account has-text-centered">
-                    <label for="name">アカウント名</label>
+                    <label for="name">アカウント名<span class="has-text-danger">255文字以内</span></label>
                     <div class="control mt-3">
                         <form action="{{ route('user.update.name') }}" method="POST">
                             @csrf

--- a/resources/views/EngineerStack/account.blade.php
+++ b/resources/views/EngineerStack/account.blade.php
@@ -145,7 +145,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -98,10 +98,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/all_categories.blade.php
+++ b/resources/views/EngineerStack/all_categories.blade.php
@@ -99,8 +99,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/change-email-form.blade.php
+++ b/resources/views/EngineerStack/change-email-form.blade.php
@@ -100,7 +100,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/EngineerStack/change-email-form.blade.php
+++ b/resources/views/EngineerStack/change-email-form.blade.php
@@ -101,8 +101,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/change-password-form.blade.php
+++ b/resources/views/EngineerStack/change-password-form.blade.php
@@ -124,8 +124,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/change-password-form.blade.php
+++ b/resources/views/EngineerStack/change-password-form.blade.php
@@ -123,7 +123,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -78,8 +78,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/deleted_memo.blade.php
+++ b/resources/views/EngineerStack/deleted_memo.blade.php
@@ -77,10 +77,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -83,7 +83,7 @@
                     <i class="fas fa-bookmark"></i><span id="categories"></span>
                 </div>
                 <div class="memo mt-5">
-                    <div class="memo-container">
+                    <div class="memo-container" style="word-break: break-all">
                         <p class="is-size-4">{{ $memo->memo }}</p>
                     </div>
                     <div class="settings has-text-right mt-4">
@@ -186,7 +186,6 @@
             $("#modal-close").click(function() {
                 $(".modal").toggleClass("is-active");
             });
-
         });
     </script>
 </body>

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -150,10 +150,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/detailed_memo.blade.php
+++ b/resources/views/EngineerStack/detailed_memo.blade.php
@@ -151,8 +151,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -122,10 +122,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/edit_memo.blade.php
+++ b/resources/views/EngineerStack/edit_memo.blade.php
@@ -123,8 +123,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/guidelines.blade.php
+++ b/resources/views/EngineerStack/guidelines.blade.php
@@ -174,8 +174,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/guidelines.blade.php
+++ b/resources/views/EngineerStack/guidelines.blade.php
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+    <title>利用規約 EngineerStack</title>
+</head>
+<body>
+    @guest
+        <section class="header">
+            <nav class="navbar" role="navigation" aria-label="main navigation">
+                <div class="navbar-brand">
+                    <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('login') }}">
+                        EngineerStack
+                    </a>
+                    <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div id="navbarBasicExample" class="navbar-menu">
+                    <div class="navbar-end">
+                        <div class="navbar-item">
+                            <div class="buttons">
+                                <a class="button is-primary" href="{{ route('register') }}">
+                                    <strong>アカウント作成</strong>
+                                </a>
+                                <a class="button is-light" href="{{ route('login') }}">
+                                    ログイン
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </section>
+    @else 
+        <section class="header">
+            <nav class="navbar" role="navigation" aria-label="main navigation">
+                <div class="navbar-brand">
+                    <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
+                        EngineerStack
+                    </a>
+                    <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div id="navbarBasicExample" class="navbar-menu">
+                    <div class="navbar-end">
+                        <div class="navbar-item">
+                            <div class="field ml-5">
+                                <div class="control has-icons-left has-icons-right">
+                                    <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                        @csrf 
+                                        <div class="input-keyword">
+                                            <input class="input is-success is-6" type="text" name="search_word" placeholder="メモ本文を検索" required>
+                                            <span class="icon is-small is-left">
+                                                <i class="fas fa-search"></i>
+                                            </span>
+                                        </div>
+                                        <div class="select">
+                                            <select name="sort">
+                                                <option value="ascend">最新のメモを検索</option>
+                                                <option value="descend">古い順に検索</option>
+                                            </select>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="navbar-item">
+                            <div class="buttons">
+                                <a class="button is-primary" href="{{ route('memos.get.input') }}">
+                                    <strong>記録</strong>
+                                </a>
+                                <form action="{{ route('logout') }}" method="POST">
+                                    @csrf
+                                    <input type="submit" class="button is-light" value="ログアウト">
+                                </form>
+                            </div>
+                        </div>
+                        <div class="navbar-item">
+                            <form action="{{ route('user.show') }}" method="GET">
+                                @csrf
+                                <button style="background: transparent; border:transparent"><i class="fas fa-user has-text-info is-size-4"></i></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </section>
+    @endguest
+    <section class="content has-background-primary m-5 p-5">
+        <div class="guidelines">
+            <h1 class="has-text-white">利用規約</h1>
+            <p class="has-text-white">この利用規約（以下，「本規約」といいます。）は，EngineerStack（以下，「当方」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
+            <h1 class="has-text-white">第1条（適用）</h1>
+            <p class="has-text-white">1.本規約は，ユーザーと当方との間の本サービスの利用に関わる一切の関係に適用されるものとします。</p>
+            <p class="has-text-white">2.当方は本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。</p>
+            <p class="has-text-white">3.本規約の規定が前条の個別規定の規定と矛盾する場合には，個別規定において特段の定めなき限り，個別規定の規定が優先されるものとします。</p>
+            <h1 class="has-text-white">第2条（利用登録)</h1>
+            <p class="has-text-white">1.本サービスにおいては，登録希望者が本規約に同意の上，運営元の定める方法によって利用登録を申請し，当方がこの承認を登録希望者に通知することによって，利用登録が完了するものとします。</p>
+            <p class="has-text-white">2.当方は，利用登録の申請者に以下の事由があると判断した場合，利用登録の申請を承認しないことがあり，その理由については一切の開示義務を負わないものとします。</p>
+            <ol class="has-text-white">
+                <li>利用登録の申請に際して虚偽の事項を届け出た場合</li>
+                <li>本規約に違反したことがある者からの申請である場合</li>
+                <li>その他，当方が利用登録を相当でないと判断した場合</li>
+            </ol>
+            <h1 class="has-text-white">第3条（ユーザーIDおよびパスワードの管理）</h1>
+            <ol class="has-text-white">
+                <li>ユーザーは，自己の責任において，本サービスのユーザーIDおよびパスワードを適切に管理するものとします。</li>
+                <li>ユーザーは，いかなる場合にも，ユーザーIDおよびパスワードを第三者に譲渡または貸与し，もしくは第三者と共用することはできません。当方は，ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には，そのユーザーIDを登録しているユーザー自身による利用とみなします。</li>
+                <li>ユーザーID及びパスワードが第三者によって使用されたことによって生じた損害は，当方に故意又は重大な過失がある場合を除き，当方は一切の責任を負わないものとします。</li>
+            </ol>
+            <h1 class="has-text-white">第4条（禁止事項）</h1>
+            <ol class="has-text-white">
+                <li>法令または公序良俗に違反する行為</li>
+                <li>犯罪行為に関連する行為</li>
+                <li>当方，本サービスの他のユーザー，または第三者のサーバーまたはネットワークの機能を破壊したり，妨害したりする行為</li>
+                <li>当方のサービスの運営を妨害するおそれのある行為</li>
+                <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+                <li>不正アクセスをし，またはこれを試みる行為</li>
+                <li>他のユーザーに成りすます行為</li>
+                <li>当方，本サービスの他のユーザーまたは第三者の知的財産権，肖像権，プライバシー，名誉その他の権利または利益を侵害する行為</li>
+                <li>その他，当方が不適切と判断する行為</li>
+            </ol>
+            <h1 class="has-text-white">第5条（利用制限および登録抹消）</h1>
+            <ol class="has-text-white">
+                <li>当方は，ユーザーが以下のいずれかに該当する場合には，事前の通知なく，投稿データを削除し，ユーザーに対して本サービスの全部もしくは一部の利用を制限しまたはユーザーとしての登録を抹消することができるものとします。</li>
+                <ol>
+                    <li>本規約のいずれかの条項に違反した場合</li>
+                    <li>その他，当方が本サービスの利用を適当でないと判断した場合</li>
+                </ol>
+            </ol>
+            <h1 class="has-text-white">第6条（退会）</h1>
+            <p class="has-text-white">ユーザーは，当方の定める退会手続により，本サービスから退会できるものとします。</p>
+            <h1 class="has-text-white">第7条（サービス内容の変更等）</h1>
+            <p class="has-text-white">当方は，ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。</p>
+            <h1 class="has-text-white">第8条（利用規約の変更）</h1>
+            <ol class="has-text-white">
+                <li>
+                    当方は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+                    <ol>
+                        <li>本規約の変更がユーザーの一般の利益に適合するとき。</li>
+                        <li>本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。</li>
+                    </ol>
+                </li>
+                <li>当方はユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</li>
+            </ol>
+            <h1 class="has-text-white">第9条（個人情報の取扱い）</h1>
+            <p class="has-text-white">当社は，本サービスの利用によって取得する個人情報については，当社「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
+            <h1 class="has-text-white">第10条（準拠法・裁判管轄）</h1>
+            <ol class="has-text-white">
+                <li>本規約の解釈にあたっては，日本法を準拠法とします。</li>
+                <li>本サービスに関して紛争が生じた場合には，当方の所在地を管轄する裁判所を専属的合意管轄とします。</li>
+            </ol>
+            <p class="has-text-white is-pulled-right">以上</p>
+            <br><br>
+        </div>
+    </section>
+    <section class="footer">
+        <div class="columns">
+            <div class="column">
+                <a class="navbar-item is-size-5 has-text-weight-semibold has-text-primary" href="{{ route('login') }}">
+                    EngineerStack
+                </a>
+                <span class="m-3">&copy;otake619 2021</span>
+            </div>
+            <div class="column m-3">
+                <p class="mb-3">EngineerStack</p>
+                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="">リリース</a><br>
+                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
+            </div>
+        </div>
+    </section>
+    <script src="{{ asset('js/app.js') }}"></script>
+    <script src="{{ asset('js/navbar.js') }}"></script>
+</body>
+</html>

--- a/resources/views/EngineerStack/guidelines.blade.php
+++ b/resources/views/EngineerStack/guidelines.blade.php
@@ -153,7 +153,7 @@
                 <li>当方はユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</li>
             </ol>
             <h1 class="has-text-white">第9条（個人情報の取扱い）</h1>
-            <p class="has-text-white">当社は，本サービスの利用によって取得する個人情報については，当社「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
+            <p class="has-text-white">当方は，本サービスの利用によって取得する個人情報については，当方「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
             <h1 class="has-text-white">第10条（準拠法・裁判管轄）</h1>
             <ol class="has-text-white">
                 <li>本規約の解釈にあたっては，日本法を準拠法とします。</li>
@@ -173,7 +173,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -141,7 +141,7 @@
                                 @endforeach
                             </div><br>
                             <div class="memo-container mb-3" style="word-break: break-all">
-                                <p class="memo" style="word-wrap: break-word;">{{ Str::limit($memo->memo, 100) }}</p>
+                                <p class="memo" style="word-wrap: break-word;">{!! nl2br(e(Str::limit($memo->memo, 100))) !!}</p>
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -202,14 +202,5 @@
     <script src="https://code.jquery.com/jquery-3.6.0.js"
                 integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
                 crossorigin="anonymous"></script>
-    <script>
-        $(function () {
-
-        });
-
-        function truncate(str){
-            return str.length <= 100 ? str: (str.substr(0, 100)+"...");
-        }
-    </script>
 </body>
 </html>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -192,8 +192,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -28,7 +28,7 @@
                                 <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
                                     @csrf 
                                     <div class="input-keyword">
-                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="キーワードで検索" maxlength="100" required>
+                                        <input class="input is-success is-6" type="text" name="search_word" placeholder="メモ本文を検索" required>
                                         <span class="icon is-small is-left">
                                             <i class="fas fa-search"></i>
                                         </span>
@@ -89,6 +89,7 @@
         <section class="content">
             <div class="title has-text-centered m-5">
                 <p class="is-size-4 is-text-weight-bold">メモ一覧</p>
+                <p class="is-size-4 is-text-weight-bold">Showing {{ $memos->firstItem() }} to {{ $memos->lastItem() }} of {{ $memos->total() }} results</p>
             </div>
             <div class="columns">
                 <div class="column is-4">
@@ -131,15 +132,15 @@
                         </nav>
                     </div>
                 </div>
-                <div class="memos columns is-multiline">
+                <div class="memos columns is-multiline is-centered p-5">
                     @foreach($memos as $memo)
-                        <div class="column is-5 box m-3" style="min-width: 300px; max-height: 300px;">
+                        <div class="column is-four-fifths box m-3" style="min-width: 300px; max-height: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     <span class="tag is-size-6 m-1"><i class="fas fa-bookmark"></i>{{ Str::limit($category, 15) }}</span>
                                 @endforeach
                             </div><br>
-                            <div class="memo-container mb-3">
+                            <div class="memo-container mb-3" style="word-break: break-all">
                                 <p class="memo" style="word-wrap: break-word;">{{ Str::limit($memo->memo, 100) }}</p>
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 

--- a/resources/views/EngineerStack/home.blade.php
+++ b/resources/views/EngineerStack/home.blade.php
@@ -191,7 +191,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -134,10 +134,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/input_memo.blade.php
+++ b/resources/views/EngineerStack/input_memo.blade.php
@@ -135,8 +135,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/privacy_policy.blade.php
+++ b/resources/views/EngineerStack/privacy_policy.blade.php
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+    <title>プライバシーポリシー EngineerStack</title>
+</head>
+<body>
+    @guest
+        <section class="header">
+            <nav class="navbar" role="navigation" aria-label="main navigation">
+                <div class="navbar-brand">
+                    <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('login') }}">
+                        EngineerStack
+                    </a>
+                    <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div id="navbarBasicExample" class="navbar-menu">
+                    <div class="navbar-end">
+                        <div class="navbar-item">
+                            <div class="buttons">
+                                <a class="button is-primary" href="{{ route('register') }}">
+                                    <strong>アカウント作成</strong>
+                                </a>
+                                <a class="button is-light" href="{{ route('login') }}">
+                                    ログイン
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </section>
+    @else 
+        <section class="header">
+            <nav class="navbar" role="navigation" aria-label="main navigation">
+                <div class="navbar-brand">
+                    <a class="navbar-item is-size-3 has-text-weight-semibold has-text-primary" href="{{ route('dashboard') }}">
+                        EngineerStack
+                    </a>
+                    <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                        <span aria-hidden="true"></span>
+                    </a>
+                </div>
+                <div id="navbarBasicExample" class="navbar-menu">
+                    <div class="navbar-end">
+                        <div class="navbar-item">
+                            <div class="field ml-5">
+                                <div class="control has-icons-left has-icons-right">
+                                    <form action="{{ route('memos.search') }}" method="GET" class="is-flex">
+                                        @csrf 
+                                        <div class="input-keyword">
+                                            <input class="input is-success is-6" type="text" name="search_word" placeholder="メモ本文を検索" required>
+                                            <span class="icon is-small is-left">
+                                                <i class="fas fa-search"></i>
+                                            </span>
+                                        </div>
+                                        <div class="select">
+                                            <select name="sort">
+                                                <option value="ascend">最新のメモを検索</option>
+                                                <option value="descend">古い順に検索</option>
+                                            </select>
+                                        </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="navbar-item">
+                            <div class="buttons">
+                                <a class="button is-primary" href="{{ route('memos.get.input') }}">
+                                    <strong>記録</strong>
+                                </a>
+                                <form action="{{ route('logout') }}" method="POST">
+                                    @csrf
+                                    <input type="submit" class="button is-light" value="ログアウト">
+                                </form>
+                            </div>
+                        </div>
+                        <div class="navbar-item">
+                            <form action="{{ route('user.show') }}" method="GET">
+                                @csrf
+                                <button style="background: transparent; border:transparent"><i class="fas fa-user has-text-info is-size-4"></i></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </nav>
+        </section>
+    @endguest
+    <section class="content has-background-primary m-5 p-5">
+        <div class="guidelines">
+            <h1 class="has-text-white">プライバシーポリシー</h1>
+            <p class="has-text-white">EngineerStack（以下「当方」といいます）は、以下のとおり個人情報保護方針を定め、個人情報の保護を推進致します。</p>
+            <h1 class="has-text-white">個人情報保護の管理</h1>
+            <p class="has-text-white">当方は、ユーザーの個人情報を正確かつ最新の状態に保ち、個人情報への不正アクセス・紛失・破損・改ざん・漏洩などを防止するため、セキュリティシステムの維持等の必要な措置を講じ、安全対策を実施し個人情報の厳重な管理を行ないます。</p>
+            <h1 class="has-text-white">個人情報の利用目的</h1>
+            <p class="has-text-white">ユーザーからお預かりした個人情報は、当方でのサービス運営のために利用いたします。</p>
+            <ul class="has-text-white">
+                <li>ユーザー数の把握</li>
+                <li>利用規約に違反したユーザーアカウントの凍結</li>
+            </ul>
+            <p class="has-text-white">等の目的に利用いたします。</p>
+            <h1 class="has-text-white">個人情報の第三者への開示・提供の禁止</h1>
+            <p class="has-text-white">当方は、ユーザーよりお預かりした個人情報を適切に管理し、次のいずれかに該当する場合を除き、個人情報を第三者に開示いたしません。
+                <ul class="has-text-white">
+                    <li>お客さまの同意がある場合</li>
+                    <li>法令に基づき開示することが必要である場合</li>
+                </ul>
+            </p>
+            <h1 class="has-text-white">個人情報の安全対策</h1>
+            <p class="has-text-white">当方は、個人情報の正確性及び安全性確保のために、セキュリティに万全の対策を講じています。</p>
+            <h1 class="has-text-white">ご本人の照会</h1>
+            <p class="has-text-white">ユーザーがご本人の個人情報の照会・修正・削除などをご希望される場合には、ご本人であることを確認の上、対応させていただきます。</p>
+            <h1 class="has-text-white">法令、規範の遵守と見直し</h1>
+            <p class="has-text-white">当方は、保有する個人情報に関して適用される日本の法令、その他規範を遵守するとともに、本ポリシーの内容を適宜見直し、その改善に努めます。</p>
+            <h1 class="has-text-white">お問い合せ</h1>
+            <p class="has-text-white">当方の個人情報の取扱に関するお問い合せはお問い合わせフォームにてご連絡ください。</p>
+            <br><br>
+        </div>
+    </section>
+    <section class="footer">
+        <div class="columns">
+            <div class="column">
+                <a class="navbar-item is-size-5 has-text-weight-semibold has-text-primary" href="{{ route('login') }}">
+                    EngineerStack
+                </a>
+                <span class="m-3">&copy;otake619 2021</span>
+            </div>
+            <div class="column m-3">
+                <p class="mb-3">EngineerStack</p>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
+            </div>
+        </div>
+    </section>
+    <script src="{{ asset('js/app.js') }}"></script>
+    <script src="{{ asset('js/navbar.js') }}"></script>
+</body>
+</html>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -116,9 +116,9 @@
                         </nav>
                     </div>
                 </div>
-                <div class="memos columns is-multiline">
+                <div class="memos columns is-multiline is-centered p-5">
                     @foreach($memos as $memo)
-                        <div class="memo column is-5 box m-3" style="min-width: 300px; max-height: 300px;">
+                        <div class="memo column is-four-fifths box m-3" style="min-width: 300px; max-height: 300px;">
                             <div class="category">
                                 @foreach($memo->categories->pluck('name') as $category)
                                     @if($category === $search_word)
@@ -128,7 +128,7 @@
                                     @endif
                                 @endforeach
                             </div><br>
-                            <div class="memo-container mb-3">
+                            <div class="memo-container mb-3" style="word-wrap: break-word;">
                                 <p class="memo" style="word-wrap: break-word;">{{ Str::limit($memo->memo, 100) }}</p>
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -330,8 +330,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -329,10 +329,10 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/EngineerStack/search_result.blade.php
+++ b/resources/views/EngineerStack/search_result.blade.php
@@ -129,7 +129,7 @@
                                 @endforeach
                             </div><br>
                             <div class="memo-container mb-3" style="word-wrap: break-word;">
-                                <p class="memo" style="word-wrap: break-word;">{{ Str::limit($memo->memo, 100) }}</p>
+                                <p class="memo" style="word-wrap: break-word;">{!! nl2br(e(Str::limit($memo->memo, 100))) !!}</p>
                                 <form action="{{ route('memos.show') }}" method="POST">
                                     @csrf 
                                     <input type="hidden" name="memo_id" value="{{ $memo->id }}">

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -68,8 +68,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -67,7 +67,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -71,8 +71,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -70,7 +70,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -87,8 +87,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -86,7 +86,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -124,8 +124,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -123,7 +123,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -89,7 +89,7 @@
                             <h4 class="has-text-white">登録項目を入力してください。</h4>
                             <form action="{{ route('register') }}" method="POST">
                                 @csrf
-                                <label for="name" class="has-text-white"><span class="has-text-danger">*必須 40文字以内 </span>アカウント名</label>
+                                <label for="name" class="has-text-white"><span class="has-text-danger">*必須 255文字以内 </span>アカウント名</label>
                                 <input class="input" id="name" type="text" name="name" placeholder="stack.json" required autofocus>
                                 <label for="email" class="has-text-white"><span class="has-text-danger">*必須 </span>メールアドレス</label>
                                 <input class="input" id="email" name="email" type="email" placeholder="engineer@stack.com" required>
@@ -98,10 +98,10 @@
                                 <label for="password" class="has-text-white"><span class="has-text-danger">*必須 </span>パスワード(確認用)</label>
                                 <input class="input" id="password" name="password_confirmation" type="password" placeholder="********" required>
                                 <label class="checkbox has-text-white mt-3">
-                                    <input type="checkbox">
-                                    <a href="#">利用規約</a>に同意する
+                                    <input type="checkbox" id="read_guidelines">
+                                    <a class="has-text-white is-underlined" href="{{ route('guidelines') }}">利用規約</a>に同意する
                                 </label><br>
-                                <input type="submit" class="button is-primary is-light mt-5" value="アカウント作成">
+                                <input type="submit" id="submit" class="button is-primary is-light mt-5" value="アカウント作成" disabled>
                             </form>
                             <br>
                             <a class="has-text-white" href="{{ route('login') }}">登録済みの場合はこちら</a>
@@ -131,5 +131,18 @@
     </section>
     <script src="{{ asset('js/app.js') }}"></script>
     <script src="{{ asset('js/navbar.js') }}"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.js"
+                integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
+                crossorigin="anonymous"></script>
+    <script>
+        $('input[type="checkbox"]').change(function() {
+            let is_checked = $(this).prop('checked');
+            if(is_checked) {
+                $('#submit').prop('disabled', false);
+            } else {
+                $('#submit').prop('disabled', true);
+            }
+        });
+    </script>
 </body>
 </html>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -84,7 +84,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -85,8 +85,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -77,8 +77,7 @@
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
                 <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -76,7 +76,7 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
                 <a class="has-text-primary" href="">リリース</a><br>
                 <a class="has-text-primary" href="">プライバシーポリシー</a><br>
                 <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>

--- a/resources/views/contact/confirm.blade.php
+++ b/resources/views/contact/confirm.blade.php
@@ -108,10 +108,9 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -152,10 +152,9 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/resources/views/contact/thanks.blade.php
+++ b/resources/views/contact/thanks.blade.php
@@ -73,10 +73,9 @@
             </div>
             <div class="column m-3">
                 <p class="mb-3">EngineerStack</p>
-                <a class="has-text-primary" href="">利用規約</a><br>
-                <a class="has-text-primary" href="">リリース</a><br>
-                <a class="has-text-primary" href="">プライバシーポリシー</a><br>
-                <a class="has-text-primary" href="">お問い合わせ</a>
+                <a class="has-text-primary" href="{{ route('guidelines') }}">利用規約</a><br>
+                <a class="has-text-primary" href="{{ route('privacy_policy') }}">プライバシーポリシー</a><br>
+                <a class="has-text-primary" href="{{ route('contact.index') }}">お問い合わせ</a>
             </div>
         </div>
     </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,10 @@ Route::prefix('users')->group(function () {
     Route::post('update_password', [UserController::class, 'updatePassword'])->middleware('throttle:3, 1')->name('user.update.password');
     Route::get('reset/{token}', [ChangeEmailController::class, 'reset'])->name('email.reset');
     Route::post('destroy', [UserController::class, 'destroy'])->name('user.destroy');
+    Route::get('guidelines', function (){
+        return view('EngineerStack.guidelines');
+    })->name('guidelines');
+    
 });
 
 Route::prefix('memos')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,9 @@ Route::prefix('users')->group(function () {
     Route::get('guidelines', function (){
         return view('EngineerStack.guidelines');
     })->name('guidelines');
-    
+    Route::get('privacy_policy', function (){
+        return view('EngineerStack.privacy_policy');
+    })->name('privacy_policy');
 });
 
 Route::prefix('memos')->group(function () {


### PR DESCRIPTION
本来であれば適切なブランチにコミットするべきだが、一緒にしてしまった。
次からは適切なブランチと単位でコミットする。
利用規約とプライバシーポリシー画面を作成。
フッター要素(利用規約、プライバシーポリシー)を設定。
アカウント作成時に「利用規約に同意」欄にチェックを入れないと
Submitがdisableのままになるように設定。
メモ詳細画面とホーム画面で、改行が反映されるように設定。
ホーム画面のメモ表示を見やすさから、2列から1列に変更した。
